### PR TITLE
Cluster Autoscaler, Kube2IAM, Fluentd-cloudwatch, ALB-ingress-controller addons

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -23,6 +23,12 @@ then
     terraform destroy -var-file="workspaces/$1/terraform.tfvars" \
     -var 'blue_nodes_enabled=0' \
     -var 'green_nodes_enabled=1' \
+    -target=module.blue_nodes \
+    -target=module.green_nodes
+
+    terraform destroy -var-file="workspaces/$1/terraform.tfvars" \
+    -var 'blue_nodes_enabled=0' \
+    -var 'green_nodes_enabled=1'
 #
 # Patch the cluster if it exists
 #

--- a/infra/modules/addons/alb_ingress.tf
+++ b/infra/modules/addons/alb_ingress.tf
@@ -17,8 +17,8 @@ resource "kubernetes_namespace" "ingress-controller" {
 
 resource "helm_release" "alb-ingress" {
   name       = "alb-ingress"
-  repository = "{data.helm_repository.incubator.metadata.0.name}"
-  chart      = "alb-ingress"
+  repository = "${data.helm_repository.incubator.metadata.0.name}"
+  chart      = "aws-alb-ingress-controller"
   namespace  = "ingress-controller"
 
   set {

--- a/infra/modules/addons/cloudwatch_logs.tf
+++ b/infra/modules/addons/cloudwatch_logs.tf
@@ -10,6 +10,16 @@ variable "cw_log_retention" {
   default = 90
 }
 
+resource "kubernetes_namespace" "fluentd" {
+  metadata {
+    name = "fluentd"
+
+    labels {
+        managed-by = "Terraform"
+    }
+  }
+}
+
 resource "aws_cloudwatch_log_group" "datakube" {
   count             = "${var.cloudwatch_logs_enabled}"
   name              = "${var.cluster_name}-${var.cw_log_group}"
@@ -23,6 +33,37 @@ resource "aws_cloudwatch_log_group" "datakube" {
 
 # ======================================
 # Fluentd
+
+
+resource "helm_release" "fluentd-cloudwatch" {
+  name       = "fluentd-cloudwatch"
+  repository = "{data.helm_repository.incubator.metadata.0.name}"
+  chart      = "fluentd-cloudwatch"
+  namespace  = "fluentd"
+
+  values = [
+    "${file("${path.module}/config/fluentd-cloudwatch.yaml")}",
+  ]
+
+  set {
+    name = "awsRole"
+    value = "${var.cluster_name}-fluentd"
+  }
+
+  set {
+    name = "logGroupName"
+    value = "${var.cluster_name}"
+  }
+
+  set {
+    name = "awsRegion"
+    value = "${data.aws_region.current.name}"
+  }
+
+  # Uses kube2iam for credentials
+  depends_on = ["helm_release.kube2iam", "aws_iam_role.fluentd", "aws_iam_role_policy.fluentd", "kubernetes_namespace.fluentd"]
+}
+
 resource "aws_iam_role" "fluentd" {
   count = "${var.cloudwatch_logs_enabled}"
   name  = "${var.cluster_name}-fluentd"

--- a/infra/modules/addons/cloudwatch_logs.tf
+++ b/infra/modules/addons/cloudwatch_logs.tf
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_log_group" "datakube" {
 
 resource "helm_release" "fluentd-cloudwatch" {
   name       = "fluentd-cloudwatch"
-  repository = "{data.helm_repository.incubator.metadata.0.name}"
+  repository = "${data.helm_repository.incubator.metadata.0.name}"
   chart      = "fluentd-cloudwatch"
   namespace  = "fluentd"
 

--- a/infra/modules/addons/cluster_autoscaler.tf
+++ b/infra/modules/addons/cluster_autoscaler.tf
@@ -16,7 +16,7 @@ resource "kubernetes_namespace" "cluster-autoscaler" {
 }
 
 resource "helm_release" "cluster_autoscaler" {
-  name       = "fluentd-cloudwatch"
+  name       = "cluster-autoscaler"
   repository = "${data.helm_repository.stable.metadata.0.name}"
   chart      = "cluster-autoscaler"
   namespace  = "cluster-autoscaler"

--- a/infra/modules/addons/cluster_autoscaler.tf
+++ b/infra/modules/addons/cluster_autoscaler.tf
@@ -17,7 +17,7 @@ resource "kubernetes_namespace" "cluster-autoscaler" {
 
 resource "helm_release" "cluster_autoscaler" {
   name       = "fluentd-cloudwatch"
-  repository = "{data.helm_repository.stable.metadata.0.name}"
+  repository = "${data.helm_repository.stable.metadata.0.name}"
   chart      = "cluster-autoscaler"
   namespace  = "cluster-autoscaler"
 

--- a/infra/modules/addons/config/autoscaler.yaml
+++ b/infra/modules/addons/config/autoscaler.yaml
@@ -1,0 +1,9 @@
+cloudProvider: aws
+rbac:
+  create: true
+serviceMonitor:
+  enabled: true
+sslCertPath: /etc/kubernetes/pki/ca.crt
+extraArgs:
+  balance-similar-node-groups: true
+  skip-nodes-with-system-pods: false

--- a/infra/modules/addons/config/autoscaler.yaml
+++ b/infra/modules/addons/config/autoscaler.yaml
@@ -1,8 +1,6 @@
 cloudProvider: aws
 rbac:
   create: true
-serviceMonitor:
-  enabled: true
 sslCertPath: /etc/kubernetes/pki/ca.crt
 extraArgs:
   balance-similar-node-groups: true

--- a/infra/modules/addons/config/fluentd-cloudwatch.yaml
+++ b/infra/modules/addons/config/fluentd-cloudwatch.yaml
@@ -1,0 +1,14 @@
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v1.3-debian-cloudwatch
+rbac:
+  create: true
+extraVars:
+  - "{ name: FLUENT_UID, value: '0' }"
+resources:
+  limits:
+    cpu: 100m
+    memory: 500Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi

--- a/infra/modules/addons/main.tf
+++ b/infra/modules/addons/main.tf
@@ -15,7 +15,7 @@ data "aws_region" "current" {}
 
 resource "helm_release" "kube2iam" {
   name       = "kube2iam"
-  repository = "{data.helm_repository.stable.metadata.0.name}"
+  repository = "${data.helm_repository.stable.metadata.0.name}"
   chart      = "kube2iam"
   namespace  = "kube-system"
 

--- a/infra/modules/addons/main.tf
+++ b/infra/modules/addons/main.tf
@@ -1,0 +1,26 @@
+provider "helm" {
+  # kubernetes {
+  #   config_path = "$HOME/.kube/config-eks.yaml"
+  # }
+}
+
+provider "kubernetes" {
+  # load_config_file       = "$HOME/.kube/config-eks.yaml"
+  # config_context_cluster = "aws"
+}
+
+# region and kube2iam required for most add-ons
+
+data "aws_region" "current" {}
+
+resource "helm_release" "kube2iam" {
+  name       = "kube2iam"
+  repository = "{data.helm_repository.stable.metadata.0.name}"
+  chart      = "kube2iam"
+  namespace  = "kube-system"
+
+  set {
+    name  = "extraArgs.base-role-arn"
+    value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/"
+  }
+}

--- a/infra/modules/addons/repositories.tf
+++ b/infra/modules/addons/repositories.tf
@@ -1,0 +1,19 @@
+data "helm_repository" "stable" {
+  name = "stable"
+  url  = "https://kubernetes-charts.storage.googleapis.com"
+}
+
+data "helm_repository" "incubator" {
+  name = "incubator"
+  url  = "https://kubernetes-charts-incubator.storage.googleapis.com"
+}
+
+data "helm_repository" "coreos" {
+  name = "coreos"
+  url  = "https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/"
+}
+
+data "helm_repository" "weaveworks" {
+  name = "weaveworks"
+  url  = "https://weaveworks.github.io/flux"
+}


### PR DESCRIPTION
This PR integrates K8s namespaces and Helm Releases controlled by Terraform to deploy the following charts:
- Kube2IAM
It also includes the following charts which are released if enabled in Terraform variables:
- Cluster Autoscaler
- Fluentd Cloudwatch
- ALB Ingress Controller

In addition a multi-stage destroy is added to the deploy script for the blue/green nodes