### PR TITLE
Add provider to infra root so env variable no longer required and it …

### DIFF
--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "${var.region}"
+}


### PR DESCRIPTION
…is clear the region is set by the terraform.tfvars variable.
