### PR TITLE
Use absolute path, as realpath is an additonal dependency

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -12,7 +12,7 @@ if [ -z $1 ] || [ -z $2 ]; then
 fi
 
 export WORKSPACE=$1
-export WORKSPACESPATH=$(realpath $2)
+export WORKSPACESPATH=$2
 
 # build network and EKS masters
 pushd infra

--- a/destroy.sh
+++ b/destroy.sh
@@ -12,7 +12,7 @@ if [ -z $1 ] || [ -z $2 ]; then
 fi
 
 export WORKSPACE=$1
-export WORKSPACESPATH=$(realpath $2)
+export WORKSPACESPATH=$2
 
 # delete addons
 pushd addons

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,13 @@ for running datacube applications.
 ```bash
 make apply workspace=<workspace name> workspaces=<workspaces path>
 ```
+
+For example
+
+```bash
+make apply workspace=datakube-dev workspaces=$(pwd)/examples/quickstart/workspaces
+```
+
 ## Destroy Kubernetes Cluster
 ```bash
 make destroy workspace=<workspace name> workspaces=<workspaces path>


### PR DESCRIPTION
Realpath isn't installed on OSX and new versions of debian by default. 

The error message we throw isn't very helpful when it isn't installed too.

By expecting an absolute path instead, we let users use their own tools when calling make apply.

