### PR TITLE
Blue / Green patching scripts

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -28,10 +28,18 @@ popd
 # build worker nodes
 pushd nodes
 terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg 
-# this is no longer only 'blue' workers nodes, however maintain the $WORKSPACE-blue for backwards compatibility
-# with older stacks
+
 terraform workspace new "$WORKSPACE-blue" || terraform workspace select "$WORKSPACE-blue"
-terraform apply -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" 
+terraform apply -auto-approve -input=false \
+    -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" \
+    -var group_enabled=true \
+    -var node_group_name=blue
+
+terraform workspace new "$WORKSPACE-green" || terraform workspace select "$WORKSPACE-green"
+terraform apply -auto-approve -input=false \
+    -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" \
+    -var group_enabled=false \
+    -var node_group_name=green
 popd
 
 pushd addons

--- a/apply.sh
+++ b/apply.sh
@@ -28,6 +28,8 @@ popd
 # build worker nodes
 pushd nodes
 terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg 
+# this is no longer only 'blue' workers nodes, however maintain the $WORKSPACE-blue for backwards compatibility
+# with older stacks
 terraform workspace new "$WORKSPACE-blue" || terraform workspace select "$WORKSPACE-blue"
 terraform apply -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" 
 popd

--- a/destroy.sh
+++ b/destroy.sh
@@ -18,7 +18,7 @@ export WORKSPACESPATH=$2
 pushd addons
 # rm -rf .terraform
 # rm -rf terraform.tfstate.d
-terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg 
+terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg
 terraform workspace new "$WORKSPACE-addons" || terraform workspace select "$WORKSPACE-addons"
 terraform destroy -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" 
 
@@ -28,8 +28,11 @@ popd
 pushd nodes
 # rm -rf .terraform
 # rm -rf terraform.tfstate.d
-terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg 
+terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg
 terraform workspace new "$WORKSPACE-blue" || terraform workspace select "$WORKSPACE-blue"
+terraform destroy -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars"
+
+terraform workspace new "$WORKSPACE-green" || terraform workspace select "$WORKSPACE-green"
 terraform destroy -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" 
 
 popd
@@ -38,6 +41,6 @@ popd
 pushd infra
 # rm -rf .terraform
 # rm -rf terraform.tfstate.d 
-terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg 
+terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg
 terraform destroy -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" 
 popd

--- a/drain_and_wait.sh
+++ b/drain_and_wait.sh
@@ -1,0 +1,45 @@
+current_nodegroup="$1"
+
+kubectl taint nodes --all=true key:NoSchedule- || echo "Removed Taints"
+
+# taint the existing nodegroup so no new pods will schedule
+kubectl taint nodes -l nodegroup=$current_nodegroup key=value:NoSchedule --overwrite=true
+
+# ensure we have 2 dns pods running
+kubectl scale deployments/coredns --replicas=2 -n kube-system
+
+# Safely drain each node in the group
+nodes=($(kubectl get nodes -l nodegroup=$current_nodegroup -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'))
+for i in "${nodes[@]}"
+do
+    echo "Draining node: $i"
+    kubectl drain $i --ignore-daemonsets --delete-local-data || echo "Node $i no longer exists"
+
+    # Wait max 15 mins per nodes for deployments to be healthy
+    max_wait=900
+    ready=false
+    while [[ $max_wait -gt 0 ]] && [ $ready == false ]; do
+        # Wait first to ensure the drain has started
+        sleep 10
+        max_wait=$(($max_wait - 10))
+        echo "Waited 10 seconds. Still waiting max. $max_wait"
+
+        # Check if deployments are healthy
+
+        ready=true 
+        deployment=($(kubectl get deployments --all-namespaces | tail -n +2 | awk '{print $2}'))
+        desired=($(kubectl get deployments --all-namespaces | tail -n +2 | awk '{print $3}'))
+        available=($(kubectl get deployments --all-namespaces | tail -n +2 | awk '{print $6}'))
+        count="${#deployment[@]}"
+        for (( i=0; i<$count; i++ )); do
+            if [  "${available[$i]}" -lt "${desired[$i]}" ]; then
+                echo "Deployment ${deployment[$i]} not ready, desired pods: ${desired[$i]}, available pods: ${available[$i]}"
+                ready=false 
+            fi
+        done
+        echo "Deployments ready: $ready"
+    done
+done
+
+# drain all pods from the nodes, continue even if we are using empytyDir 
+kubectl drain -l nodegroup=$current_nodegroup --ignore-daemonsets --delete-local-data

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -42,9 +42,11 @@ locals {
   endpoint              = "${element(data.aws_eks_cluster.eks.*.endpoint, 0)}"
   certificate_authority = "${element(data.aws_eks_cluster.eks.*.certificate_authority.0.data, 0)}"
   node_security_group   = "${element(data.aws_security_groups.nodes.ids, 0)}"
+  green_enabled         = "${contains(var.enabled_groups, "green")}"
+  blue_enabled          = "${contains(var.enabled_groups, "blue")}"
 }
 
-module "nodes" {
+module "green" {
   source = "modules/workers"
 
   cluster_name          = "${var.cluster_name}"
@@ -57,8 +59,31 @@ module "nodes" {
   node_instance_profile = "${var.cluster_name}-node"
   min_nodes             = "${var.min_nodes_per_az}"
   max_nodes             = "${var.max_nodes_per_az}"
-  node_group_name       = "${var.node_group_name}"
+  node_group_name       = "green"
   ami_image_id          = "${var.ami_image_id}"
-  spot_nodes_enabled    = "${var.spot_nodes_enabled}"
+  spot_nodes_enabled    = "${local.green_enabled && var.spot_nodes_enabled}"
   max_spot_price        = "${var.max_spot_price}"
+  nodes_enabled         = "${local.green_enabled}"
+  desired_nodes         = 1
+}
+
+module "blue" {
+  source = "modules/workers"
+
+  cluster_name          = "${var.cluster_name}"
+  owner                 = "${var.owner}"
+  eks_cluster_version   = "${local.eks_cluster_version}"
+  api_endpoint          = "${local.endpoint}"
+  cluster_ca            = "${local.certificate_authority}"
+  nodes_subnet_group    = "${data.aws_subnet_ids.nodes.ids}"
+  node_security_group   = "${local.node_security_group}"
+  node_instance_profile = "${var.cluster_name}-node"
+  min_nodes             = "${var.min_nodes_per_az}"
+  max_nodes             = "${var.max_nodes_per_az}"
+  nodes_enabled         = "${local.blue_enabled}"
+  node_group_name       = "blue"
+  ami_image_id          = "${var.ami_image_id}"
+  spot_nodes_enabled    = "${local.blue_enabled && var.spot_nodes_enabled}"
+  max_spot_price        = "${var.max_spot_price}"
+  desired_nodes         = 1
 }

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -42,11 +42,9 @@ locals {
   endpoint              = "${element(data.aws_eks_cluster.eks.*.endpoint, 0)}"
   certificate_authority = "${element(data.aws_eks_cluster.eks.*.certificate_authority.0.data, 0)}"
   node_security_group   = "${element(data.aws_security_groups.nodes.ids, 0)}"
-  green_enabled         = "${contains(var.enabled_groups, "green")}"
-  blue_enabled          = "${contains(var.enabled_groups, "blue")}"
 }
 
-module "green" {
+module "workers" {
   source = "modules/workers"
 
   cluster_name          = "${var.cluster_name}"
@@ -59,31 +57,10 @@ module "green" {
   node_instance_profile = "${var.cluster_name}-node"
   min_nodes             = "${var.min_nodes_per_az}"
   max_nodes             = "${var.max_nodes_per_az}"
-  node_group_name       = "green"
+  node_group_name       = "${var.node_group_name}"
   ami_image_id          = "${var.ami_image_id}"
-  spot_nodes_enabled    = "${local.green_enabled && var.spot_nodes_enabled}"
+  spot_nodes_enabled    = "${var.group_enabled && var.spot_nodes_enabled}"
   max_spot_price        = "${var.max_spot_price}"
-  nodes_enabled         = "${local.green_enabled}"
-  desired_nodes         = "${var.desired_nodes_per_az}"
-}
-
-module "blue" {
-  source = "modules/workers"
-
-  cluster_name          = "${var.cluster_name}"
-  owner                 = "${var.owner}"
-  eks_cluster_version   = "${local.eks_cluster_version}"
-  api_endpoint          = "${local.endpoint}"
-  cluster_ca            = "${local.certificate_authority}"
-  nodes_subnet_group    = "${data.aws_subnet_ids.nodes.ids}"
-  node_security_group   = "${local.node_security_group}"
-  node_instance_profile = "${var.cluster_name}-node"
-  min_nodes             = "${var.min_nodes_per_az}"
-  max_nodes             = "${var.max_nodes_per_az}"
-  nodes_enabled         = "${local.blue_enabled}"
-  node_group_name       = "blue"
-  ami_image_id          = "${var.ami_image_id}"
-  spot_nodes_enabled    = "${local.blue_enabled && var.spot_nodes_enabled}"
-  max_spot_price        = "${var.max_spot_price}"
+  nodes_enabled         = "${var.group_enabled}"
   desired_nodes         = "${var.desired_nodes_per_az}"
 }

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -37,6 +37,16 @@ data "aws_iam_instance_profile" "node" {
   name = "${var.cluster_name}-node"
 }
 
+data "aws_autoscaling_group" "nodes" {
+  count = "${(var.group_enabled ? 1 : 0) * length(data.aws_subnet_ids.nodes.ids)}"
+  name  = "${element(module.workers.node_asg_names, count.index)}"
+}
+
+data "aws_autoscaling_group" "spots" {
+  count = "${(var.group_enabled && var.spot_nodes_enabled ? 1 : 0) * length(data.aws_subnet_ids.nodes.ids)}"
+  name  = "${element(module.workers.spot_node_asg_names, count.index)}"
+}
+
 locals {
   eks_cluster_version   = "${element(data.aws_eks_cluster.eks.*.version, 0)}"
   endpoint              = "${element(data.aws_eks_cluster.eks.*.endpoint, 0)}"

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -64,7 +64,7 @@ module "green" {
   spot_nodes_enabled    = "${local.green_enabled && var.spot_nodes_enabled}"
   max_spot_price        = "${var.max_spot_price}"
   nodes_enabled         = "${local.green_enabled}"
-  desired_nodes         = 1
+  desired_nodes         = "${var.desired_nodes_per_az}"
 }
 
 module "blue" {
@@ -85,5 +85,5 @@ module "blue" {
   ami_image_id          = "${var.ami_image_id}"
   spot_nodes_enabled    = "${local.blue_enabled && var.spot_nodes_enabled}"
   max_spot_price        = "${var.max_spot_price}"
-  desired_nodes         = 1
+  desired_nodes         = "${var.desired_nodes_per_az}"
 }

--- a/nodes/modules/workers/outputs.tf
+++ b/nodes/modules/workers/outputs.tf
@@ -1,3 +1,11 @@
 output "ami_image_id" {
   value = "${local.ami_id}"
 }
+
+output "node_asg_names" {
+  value = "${aws_autoscaling_group.nodes.*.name}"
+}
+
+output "spot_node_asg_names" {
+  value = "${aws_autoscaling_group.spot_nodes.*.name}"
+}

--- a/nodes/modules/workers/variables.tf
+++ b/nodes/modules/workers/variables.tf
@@ -56,8 +56,3 @@ variable "spot_nodes_enabled" {
 variable "max_spot_price" {
   default = "0.40"
 }
-
-locals {
-  nodes_enabled = "${var.spot_nodes_enabled != true ? 1 : 0}"
-  spot_enabled  = "${var.spot_nodes_enabled == true ? 1 : 0}"
-}

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -28,7 +28,7 @@ USERDATA
 }
 
 resource "aws_launch_template" "node" {
-  count         = "${local.nodes_enabled * length(var.nodes_subnet_group) }"
+  count         = "${(var.nodes_enabled ? 1 : 0)  * length(var.nodes_subnet_group) }"
   name_prefix   = "${var.cluster_name}"
   image_id      = "${data.aws_ami.eks-worker.id}"
   user_data     = "${base64encode(local.eks-node-userdata)}"
@@ -51,7 +51,7 @@ resource "aws_launch_template" "node" {
 }
 
 resource "aws_launch_template" "spot" {
-  count         = "${local.spot_enabled * length(var.nodes_subnet_group) }"
+  count         = "${(var.spot_nodes_enabled ? 1 : 0)  * length(var.nodes_subnet_group) }"
   name_prefix   = "${var.cluster_name}"
   image_id      = "${data.aws_ami.eks-worker.id}"
   user_data     = "${base64encode(local.eks-node-userdata)}"

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,5 +1,5 @@
 resource "aws_autoscaling_group" "nodes" {
-  count               = "${local.nodes_enabled * length(var.nodes_subnet_group) }"
+  count               = "${(var.nodes_enabled ? 1 : 0) * length(var.nodes_subnet_group) }"
   desired_capacity    = "${var.desired_nodes}"
   max_size            = "${var.max_nodes}"
   min_size            = "${var.min_nodes}"
@@ -44,7 +44,7 @@ resource "aws_autoscaling_group" "nodes" {
 }
 
 resource "aws_autoscaling_group" "spot_nodes" {
-  count               = "${local.spot_enabled * length(var.nodes_subnet_group) }"
+  count               = "${(var.spot_nodes_enabled ? 1 : 0) * length(var.nodes_subnet_group) }"
   desired_capacity    = "${var.desired_nodes}"
   max_size            = "${var.max_nodes}"
   min_size            = "${var.min_nodes}"

--- a/nodes/outputs.tf
+++ b/nodes/outputs.tf
@@ -1,0 +1,3 @@
+output "current_node_group" {
+  value = "${var.current_node_group}"
+}

--- a/nodes/outputs.tf
+++ b/nodes/outputs.tf
@@ -1,3 +1,3 @@
-output "current_node_group" {
-  value = "${var.current_node_group}"
+output "enabled" {
+  value = "${var.group_enabled}"
 }

--- a/nodes/outputs.tf
+++ b/nodes/outputs.tf
@@ -1,3 +1,7 @@
 output "enabled" {
   value = "${var.group_enabled}"
 }
+
+output "node_desired_counts" {
+  value = "${concat(data.aws_autoscaling_group.nodes.*.desired_capacity, data.aws_autoscaling_group.spots.*.desired_capacity)}"
+}

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -1,11 +1,20 @@
 # Worker node config
 
+variable "ami_image_id" {
+  default = ""
+  description = "Overwrites the default ami (latest Amazon EKS)"
+}
+
 variable "node_group_name" {
   default = "eks"
 }
 
 variable "default_worker_instance_type" {
   default = "m4.large"
+}
+
+variable "group_enabled" {
+  default = false
 }
 
 variable "spot_nodes_enabled" {
@@ -28,13 +37,6 @@ variable "max_spot_price" {
   default = "0.40"
 }
 
-variable "ami_image_id" {
-  description = "Overwrites the default ami (latest Amazon EKS)"
-  default     = ""
-}
-
-# Data sources
-
 variable "cluster_name" {}
 
 variable "owner" {
@@ -43,14 +45,4 @@ variable "owner" {
 
 variable "region" {
 
-}
-
-variable "current_node_group" {
-  type = "string"
-  default = "blue"
-}
-
-variable "enabled_groups" {
-  type = "list"
-  default = ["blue"]
 }

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -45,3 +45,12 @@ variable "region" {
 
 }
 
+variable "current_node_group" {
+  type = "string"
+  default = "blue"
+}
+
+variable "enabled_groups" {
+  type = "list"
+  default = ["blue"]
+}

--- a/patch.sh
+++ b/patch.sh
@@ -11,23 +11,44 @@ if [ -z $1 ] || [ -z $2 ]; then
     exit 1
 fi
 
+if [ -z $3 ]; then
+    echo "No new AMI specified, cannot update workers"
+    exit 1
+fi
+
+function fail_on_workspace {
+    echo "$1 does not exist, please ensure apply.sh has been run"
+    exit 1
+}
+
 export WORKSPACE=$1
 export WORKSPACESPATH=$2
 
 # build worker nodes
 pushd nodes
 terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg
-# this is no longer only 'blue' workers nodes, however maintain the $WORKSPACE-blue for backwards compatibility
-# with older stacks
-terraform workspace new "$WORKSPACE-blue" || terraform workspace select "$WORKSPACE-blue"
-active_node_group=$(terraform output current_node_group || echo "blue")
+terraform workspace select "$WORKSPACE-green" || fail_on_workspace "$WORKSPACE-green"
+terraform workspace select "$WORKSPACE-blue" || fail_on_workspace "$WORKSPACE-blue"
+
+blue_enabled=$(terraform output enabled)
+active_node_group=$([[ "$blue_enabled" = "true" ]] && echo "blue" || echo "green")
 new_node_group=$([[ "$active_node_group" == "blue" ]] && echo "green" || echo "blue")
-echo $new_node_group
-terraform apply -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" -var enabled_groups='["blue", "green"]'
-# Drain current node group
-../drain_and_wait.sh "$active_node_group"
+
+# Create new nodes
+terraform workspace select "$WORKSPACE-$new_node_group"
 terraform apply -auto-approve -input=false \
     -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" \
-    -var enabled_groups='["'"$new_node_group"'"]' \
-    -var current_node_group="$new_node_group"
+    -var group_enabled=true \
+    -var node_group_name="$new_node_group" \
+    -var ami_image_id="$3"
+
+# Drain current nodes
+../drain_and_wait.sh "$active_node_group"
+
+# Destroy old nodes
+terraform workspace select "$WORKSPACE-$active_node_group"
+terraform apply -auto-approve -input=false \
+    -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" \
+    -var group_enabled=false \
+    -var node_group_name="$active_node_group" 
 popd

--- a/patch.sh
+++ b/patch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+#set -o xtrace
+# 
+# Patch EKS nodes
+# 
+
+if [ -z $1 ] || [ -z $2 ]; then
+    echo "Error: workspace and/or workspaces path variables not set, I don't know which workspace you want to create"
+    exit 1
+fi
+
+export WORKSPACE=$1
+export WORKSPACESPATH=$2
+
+# build worker nodes
+pushd nodes
+terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg
+# this is no longer only 'blue' workers nodes, however maintain the $WORKSPACE-blue for backwards compatibility
+# with older stacks
+terraform workspace new "$WORKSPACE-blue" || terraform workspace select "$WORKSPACE-blue"
+active_node_group=$(terraform output current_node_group || echo "blue")
+new_node_group=$([[ "$active_node_group" == "blue" ]] && echo "green" || echo "blue")
+echo $new_node_group
+terraform apply -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" -var enabled_groups='["blue", "green"]'
+# Drain current node group
+../drain_and_wait.sh "$active_node_group"
+terraform apply -auto-approve -input=false \
+    -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" \
+    -var enabled_groups='["'"$new_node_group"'"]' \
+    -var current_node_group="$new_node_group"
+popd


### PR DESCRIPTION
Allows cluster admins to run a patch script to perform a blue / green node deployment with a new AMI. Introduces a new workspace `$WORKSPACE-green` which will be default not be enabled.

Blue / Green patching remains optional. Using `apply.sh` to update the AMI of the blue worker group is still available.