### PR TITLE
Allow additional EC2 userdata for EKS worker nodes

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -27,7 +27,7 @@ terraform init -backend-config $WORKSPACESPATH/$WORKSPACE/backend.cfg
 terraform apply -auto-approve -input=false -var-file="$WORKSPACESPATH/$WORKSPACE/terraform.tfvars" 
 
 # Configure local kubernetes config
-aws eks --region $(terraform output region) update-kubeconfig --name $(terraform output cluster_name)
+aws eks --region $(terraform output region) update-kubeconfig --name $(terraform output cluster_name) --role-arn $(terraform output cluster_role)
 
 # Set up aws-auth
 popd

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -7,6 +7,10 @@ output "cluster_name" {
   value = "${var.cluster_name}"
 }
 
+output "cluster_role" {
+  value = "${module.eks.user_role_arn}"
+}
+
 output "region" {
   value = "${var.region}"
 }

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -73,4 +73,5 @@ module "workers" {
   max_spot_price        = "${var.max_spot_price}"
   nodes_enabled         = "${var.group_enabled}"
   desired_nodes         = "${var.desired_nodes_per_az}"
+  extra_userdata        = "${var.extra_userdata}"
 }

--- a/nodes/modules/workers/variables.tf
+++ b/nodes/modules/workers/variables.tf
@@ -56,3 +56,11 @@ variable "spot_nodes_enabled" {
 variable "max_spot_price" {
   default = "0.40"
 }
+
+variable "extra_userdata" {
+  type = "string"
+  description = "Additional EC2 user data commands that will be passed to EKS nodes"
+  default = <<USERDATA
+echo ""
+USERDATA
+}

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -23,7 +23,8 @@ set -o xtrace
 /etc/eks/bootstrap.sh --apiserver-endpoint '${var.api_endpoint}' --b64-cluster-ca '${var.cluster_ca}' '${var.cluster_name}' \
 --kubelet-extra-args \
   "--node-labels=cluster=${var.cluster_name},nodegroup=${var.node_group_name} \
-   --cloud-provider=aws" 
+   --cloud-provider=aws"
+${var.extra_userdata}
 USERDATA
 }
 

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -46,3 +46,11 @@ variable "owner" {
 variable "region" {
 
 }
+
+variable "extra_userdata" {
+  type = "string"
+  description = "Additional EC2 user data commands that will be passed to EKS nodes"
+  default = <<USERDATA
+echo ""
+USERDATA
+}


### PR DESCRIPTION
Add a variable for additional EC2 userdata commands passed to the EKS worker nodes.
Update the outputs for infra to include the cluster role arn.
Update the apply script to use the role-arn from the infra module when setting the EKS kubeconfig