### PR TITLE
Remove MFA conditions from user_policy so SSO credentials can be used

### DIFF
--- a/infra/modules/eks/user_policy.tf
+++ b/infra/modules/eks/user_policy.tf
@@ -24,17 +24,6 @@ data "aws_iam_policy_document" "assume_role" {
       values   = ["true"]
     }
 
-    condition {
-      test     = "Bool"
-      variable = "aws:MultiFactorAuthPresent"
-      values   = ["true"]
-    }
-
-    condition {
-      test     = "NumericLessThan"
-      variable = "aws:MultiFactorAuthAge"
-      values   = ["28800"]
-    }
   }
 }
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -71,7 +71,6 @@ output "user_profile" {
 [profile ${var.cluster_name}]
 source_profile = default
 role_arn = "${module.eks.user_role_arn}"
-mfa_serial = arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/<your user name>
 EOF
 
   sensitive = true


### PR DESCRIPTION
The condition that MFA is a requirement for valid credentials is invalid for SSO users and causes credential failures.