### PR TITLE
Minor patches

### DIFF
--- a/addons/repositories.tf
+++ b/addons/repositories.tf
@@ -25,7 +25,10 @@ data "helm_repository" "weaveworks" {
 # Initialize and destroy helm / tiller
 resource "null_resource" "helm_init_client" {
   provisioner "local-exec" {
-    command = "helm init --wait --service-account ${kubernetes_cluster_role_binding.tiller_clusterrolebinding.subject[0].name}"
+    command = <<EOF
+    helm init --wait --service-account ${kubernetes_cluster_role_binding.tiller_clusterrolebinding.subject[0].name};
+    kubectl --namespace=kube-system patch deployment tiller-deploy --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
+EOF
   }
 
   provisioner "local-exec" {

--- a/examples/quickstart/backend/provider.tf
+++ b/examples/quickstart/backend/provider.tf
@@ -1,4 +1,5 @@
 provider "aws" {
-  region      = "${var.region}"
+  region      = var.region
   max_retries = 10
 }
+

--- a/examples/quickstart/backend/terraform-backend.tf
+++ b/examples/quickstart/backend/terraform-backend.tf
@@ -1,32 +1,31 @@
 # terraform state file setup
 # create an S3 bucket to store the state file in
 resource "aws_s3_bucket" "terraform-state-storage-s3" {
-    bucket = "${var.backend_name}-tfstate"
-    region = "${var.region}"
-    acl = "private"
+  bucket = "${var.backend_name}-tfstate"
+  region = var.region
+  acl    = "private"
 
-    versioning {
-      enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    # Uncomment this to prevent unintended destruction of state
-    # lifecycle {
-    #   prevent_destroy = true
-    # }
+  # Uncomment this to prevent unintended destruction of state
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 
-    server_side_encryption_configuration {
-      rule {
-        apply_server_side_encryption_by_default {
-          sse_algorithm     = "AES256"
-        }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
       }
     }
- 
-    tags {
-      Name = "S3 Remote Terraform State Store for ${var.backend_name}"
-    }      
-}
+  }
 
+  tags = {
+    Name = "S3 Remote Terraform State Store for ${var.backend_name}"
+  }
+}
 
 # The terraform lock database resource
 resource "aws_dynamodb_table" "terraform_state_lock" {
@@ -36,18 +35,19 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
   hash_key       = "LockID"
 
   attribute {
-      name = "LockID"
-      type = "S"
+    name = "LockID"
+    type = "S"
   }
-  tags {
+  tags = {
     Name = "DynamoDB Terraform State Lock Table for ${var.backend_name}"
   }
 }
 
 output "tf-state-bucket" {
-  value = "${aws_s3_bucket.terraform-state-storage-s3.*.id}"
+  value = aws_s3_bucket.terraform-state-storage-s3.*.id
 }
 
 output "dynamodb_table" {
-  value = "${aws_dynamodb_table.terraform_state_lock.*.name}"
+  value = aws_dynamodb_table.terraform_state_lock.*.name
 }
+

--- a/examples/quickstart/backend/variables.tf
+++ b/examples/quickstart/backend/variables.tf
@@ -1,7 +1,8 @@
 variable "region" {
-    description = "The AWS region to provision resources too"
+  description = "The AWS region to provision resources too"
 }
 
 variable "backend_name" {
-    description = "The name used for creation of backend resources like the terraform state bucket"
+  description = "The name used for creation of backend resources like the terraform state bucket"
 }
+

--- a/examples/quickstart/backend/versions.tf
+++ b/examples/quickstart/backend/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This minor patch fixes to things:
1. Adds a tiller patch to help secure tiller from abuse on cluster - THIS IS UNTESTED and I'm not sure on the syntax involved for terraform multiline commands. This passes terraform plan so is valid (based on anotehr example I found). I've made this a DRAFT pull request so someone else with stronger terraform syntax skills than I can check it.
2. the examples/backend terraform files were missed in the 0.12 upgrade. This fixes it and my equivalent of them works fine.
