### PR TITLE
Require specification of EKS cluster version

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -84,6 +84,8 @@ owner = "datakube-owner"
 
 cluster_name = "dev-eks-datacube"
 
+cluster_version = "1.13"
+
 admin_access_CIDRs = {
   "Everywhere" = "0.0.0.0/0"
 }

--- a/docs/patching.md
+++ b/docs/patching.md
@@ -1,8 +1,0 @@
-# Patching
-
-We've set up automated processes to do blue / green patching of your cluster, you can run this using the following command.
-
-## Patch the worker nodes
-```bash
-make patch workspace=<cluster name> path=<path>
-```

--- a/docs/patching_upgrading.md
+++ b/docs/patching_upgrading.md
@@ -1,0 +1,22 @@
+# Patching & Upgrading
+
+## Upgrading EKS Cluster version
+> **WARNING:** Once upgraded, the EKS Cluster version cannot be downgraded in-place. If you wish to downgrade, the cluster must be destroyed and recreated with a previous version.
+
+Terraform can upgrade your EKS cluster in-place to a newer version. This will also create new worker node infrastructure to support the new EKS cluster version and destroy the old worker node infrastructure.
+
+Upgrading your EKS cluster to a newer EKS version update the value of `cluster_version` in your cluster definition [examples/quickstart/workspaces/terraform.tfvars](../examples/quickstart/workspaces/terraform.tfvars) to the EKS version desired. A list of EKS version can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html).
+
+Also ensure that the AMI specified by `ami_image_id` is compatible with the desired EKS cluster version. Alternatively `ami_image_id` can be unset, in which case terraform will automatically use a compatible AMI.
+
+Once the cluster definition has been updated run the following to apply the upgrade to your cluster:
+> **NOTE:** This may cause an outage during the upgrade when worker nodes are replaced
+```bash
+make apply workspace=<cluster name> path=<path>
+```
+
+## Patching worker nodes
+We've set up automated processes to do blue / green patching of your cluster. An AMI which the worker nodes will be upgraded to is required. In order to run the node patching you can run this using the following command:
+```bash
+make patch workspace=<cluster name> path=<path>
+```

--- a/examples/quickstart/workspaces/datakube-dev/terraform.tfvars
+++ b/examples/quickstart/workspaces/datakube-dev/terraform.tfvars
@@ -3,6 +3,8 @@ owner = "datakube-owner"
 
 cluster_name = "dev-eks-datacube"
 
+cluster_version = "1.13"
+
 admin_access_CIDRs = {
   "Everywhere" = "0.0.0.0/0"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -55,6 +55,7 @@ module "eks" {
   vpc_id             = module.vpc.vpc_id
   eks_subnet_ids     = module.vpc.private_subnets
   cluster_name       = var.cluster_name
+  cluster_version    = var.cluster_version
   admin_access_CIDRs = var.admin_access_CIDRs
   users              = var.users
   enable_ec2_ssm     = var.enable_ec2_ssm

--- a/infra/modules/eks/_variables.tf
+++ b/infra/modules/eks/_variables.tf
@@ -3,6 +3,11 @@ variable "cluster_name" {
   type    = string
 }
 
+variable "cluster_version" {
+  type = "string"
+  description = "EKS Version to use with this cluster"
+}
+
 variable "admin_access_CIDRs" {
   description = "Locks ssh and api access to these IPs"
   type        = map(string)

--- a/infra/modules/eks/master.tf
+++ b/infra/modules/eks/master.tf
@@ -1,6 +1,7 @@
 resource "aws_eks_cluster" "eks" {
   name     = var.cluster_name
   role_arn = aws_iam_role.eks-cluster.arn
+  version  = var.cluster_version
 
   vpc_config {
     security_group_ids = [aws_security_group.eks-cluster.id]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -11,6 +11,11 @@ variable "cluster_name" {
   default = "datacube-eks"
 }
 
+variable "cluster_version" {
+  type = "string"
+  description = "EKS Cluster version to use"
+}
+
 variable "admin_access_CIDRs" {
   description = "Locks ssh and api access to these IPs"
   type        = map(string)


### PR DESCRIPTION
This PR will allow (and also require) the EKS cluster version to be specified in terraform. When running this the `cluster_version` variable must be specified in your `terraform.tfvars` files. This PR will allow the cluster version to be updated using Terraform.