### PR TITLE
Update k8s provider to >1.7 to provide support for node affinity …

### DIFF
--- a/addons/main.tf
+++ b/addons/main.tf
@@ -24,6 +24,7 @@ provider "helm" {
 }
 
 provider "kubernetes" {
+  version = "~> 1.7"
   config_context_cluster = data.aws_eks_cluster.eks.arn
 }
 


### PR DESCRIPTION
(amongst other new features) - not used in datacube-k8s-eks yet but impacts upstream activities and datacube-k8s-eks can benefit later. I use the 1.7 provider in jupyterhub to ensure pods are starting on the correct nodes