### PR TITLE
Use equal signs for tag blocks

### DIFF
--- a/examples/quickstart/backend/terraform-backend.tf
+++ b/examples/quickstart/backend/terraform-backend.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket" "terraform-state-storage-s3" {
       }
     }
  
-    tags {
+    tags = {
       Name = "S3 Remote Terraform State Store for ${var.backend_name}"
     }      
 }
@@ -39,7 +39,7 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
       name = "LockID"
       type = "S"
   }
-  tags {
+  tags = {
     Name = "DynamoDB Terraform State Lock Table for ${var.backend_name}"
   }
 }


### PR DESCRIPTION
Terraform wants to have `tags = {` instead of `tags {`, otherwise it complains. Fixed accordingly.

```
$ make create-backend region=ap-southeast-2 backend=datakube-dev

Initializing the backend...

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
# terraform state file setup
suggested below.

* provider.aws: version = "~> 2.16"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Error: Unsupported block type

  on terraform-backend.tf line 25, in resource "aws_s3_bucket" "terraform-state-storage-s3":
  25:     tags {

Blocks of type "tags" are not expected here. Did you mean to define argument
"tags"? If so, use the equals sign to assign it a value.


Error: Unsupported block type

  on terraform-backend.tf line 42, in resource "aws_dynamodb_table" "terraform_state_lock":
  42:   tags {

Blocks of type "tags" are not expected here. Did you mean to define argument
"tags"? If so, use the equals sign to assign it a value.

make: *** [Makefile:2: create-backend] Error 1
```
```
$ terraform version
Terraform v0.12.3
```