### PR TITLE
escape the flux url as it breaks yaml to json conversion

### DIFF
--- a/addons/flux.tf
+++ b/addons/flux.tf
@@ -58,7 +58,7 @@ resource "helm_release" "flux" {
 
   set {
     name  = "git.url"
-    value = var.flux_git_repo_url
+    value = format("\"%s\"", var.flux_git_repo_url)
   }
 
   set {


### PR DESCRIPTION
Should fix the following error:
```
Error: rpc error: code = Unknown desc = YAML parse error on flux/templates/deployment.yaml: error converting YAML to JSON: yaml: line 78: could not find expected ':'
  on flux.tf line 48, in resource "helm_release" "flux":
  48: resource "helm_release" "flux" {
```