### PR TITLE
 update terraform file for fluxcloud parameters set up

### DIFF
--- a/addons/fluxcloud.tf
+++ b/addons/fluxcloud.tf
@@ -64,6 +64,12 @@ resource "kubernetes_deployment" "fluxcloud" {
 
   spec {
     replicas = 1
+    
+    selector {
+      match_labels = {
+        name = "fluxcloud"
+      }
+    }
 
     template {
       metadata {


### PR DESCRIPTION
In order to create a spec.template.metadata.labels , the config should match the spec.selector.match_labels.
I have created a `spec.selector.match_labels` to match the template label as provided in doc on terraform 
https://www.terraform.io/docs/providers/kubernetes/r/deployment.html?origin_team=T0L4V0TFT#labels
```By default, the provider ignores any labels whose key names end with kubernetes.io. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem). Must match selector```