### PR TITLE
Add a variable to allow configuration of the autoscaler scale down time

### DIFF
--- a/addons/_variables.tf
+++ b/addons/_variables.tf
@@ -18,3 +18,7 @@ variable "region" {
   type = string
 }
 
+variable "autoscaler-scale-down-unneeded-time" {
+  default = "10m"
+}
+

--- a/addons/cluster_autoscaler.tf
+++ b/addons/cluster_autoscaler.tf
@@ -34,6 +34,11 @@ resource "helm_release" "cluster_autoscaler" {
   }
 
   set {
+    name  = "extraArgs.scale-down-unneeded-time"
+    value = var.autoscaler-scale-down-unneeded-time
+  }
+
+  set {
     name  = "autoDiscovery.clusterName"
     value = var.cluster_name
   }


### PR DESCRIPTION
Sets scale-down-uneeded-time which defaults to 10 minutes but can be adjusted using the new variable
