### PR TITLE
Updatge cluster-autoscaler version to provide support for mixed instance types in SPOT

### DIFF
--- a/addons/cluster_autoscaler.tf
+++ b/addons/cluster_autoscaler.tf
@@ -29,6 +29,10 @@ resource "helm_release" "cluster_autoscaler" {
   ]
 
   set {
+    name = "image.tag"
+    value = "v1.14.3"
+  }
+  set {
     name  = "podAnnotations.iam\\.amazonaws\\.com/role"
     value = "${var.cluster_name}-autoscaler"
   }


### PR DESCRIPTION
This simple change enables cluster-autoscaler to support the mixed instances policy in ASG for SPOT instances - vastly improving the ability to schedule SPOT instances.

- Instructions on how to configure your ASG can be found [here](https://github.com/kubernetes/autoscaler/tree/cluster-autoscaler-release-1.14/cluster-autoscaler/cloudprovider/aws). It translates to terraform simply enough.
- If you look at that link closely you will find you are on a branch. That is the 1.14 release branch and only 1.14 or higher support this feature.
- Whilst the cluster-autoscaler notes say the version number should match the k8s version number (1.14 with this update), in the fine print it says that is what they _test_ and higher version numbers often work with previous k8s versions. AWS is clearly supported as there is active development and EKS is at 1.13 so, I took a punt and everything is working just fine, even the logs are more readable now!

