### PR TITLE
change fluxcloud to be in the flux namespace

### DIFF
--- a/addons/fluxcloud.tf
+++ b/addons/fluxcloud.tf
@@ -83,7 +83,7 @@ resource "kubernetes_deployment" "fluxcloud" {
       spec {
         container {
           name  = "fluxcloud"
-          image = "justinbarrick/fluxcloud:v0.3.6"
+          image = "justinbarrick/fluxcloud:v0.3.8"
 
           port {
             container_port = 3032

--- a/addons/fluxcloud.tf
+++ b/addons/fluxcloud.tf
@@ -42,6 +42,7 @@ resource "kubernetes_service" "fluxcloud" {
   count = var.fluxcloud_enabled ? 1 : 0
   metadata {
     name = "fluxcloud"
+    namespace = "flux"
   }
 
   spec {
@@ -60,6 +61,7 @@ resource "kubernetes_deployment" "fluxcloud" {
   count = var.fluxcloud_enabled ? 1 : 0
   metadata {
     name = "fluxcloud"
+    namespace = "flux"
   }
 
   spec {
@@ -81,7 +83,7 @@ resource "kubernetes_deployment" "fluxcloud" {
       spec {
         container {
           name  = "fluxcloud"
-          image = "justinbarrick/fluxcloud:v0.3.8"
+          image = "justinbarrick/fluxcloud:v0.3.6"
 
           port {
             container_port = 3032


### PR DESCRIPTION
# Why this change is needed
Flux is currently being deployed in the `flux` namespace, this change ensures that fluxcloud is also deployed in this namespace so they can communicate.

# Negative effects of this change
This change places a dependency from the fluxcloud addon to flux addon, but as fluxcloud requires flux to be useful, I don't believe this is a problem.
