### PR TITLE
Instance labels for spot nodes

### DIFF
--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -33,6 +33,9 @@ USERDATA
   eks-spot-userdata = <<USERDATA
 #!/bin/bash
 set -o xtrace
+# Get instance and ami id from the aws ec2 metadate endpoint 
+id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
+ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
 /etc/eks/bootstrap.sh --apiserver-endpoint '${var.api_endpoint}' --b64-cluster-ca '${var.cluster_ca}' '${var.cluster_name}' \
 --kubelet-extra-args \
   "--node-labels=cluster=${var.cluster_name},nodegroup=${var.node_group_name},nodetype=spot \

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -20,6 +20,7 @@ locals {
   eks-node-userdata = <<USERDATA
 #!/bin/bash
 set -o xtrace
+# Get instance and ami id from the aws ec2 metadate endpoint 
 id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
 ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
 /etc/eks/bootstrap.sh --apiserver-endpoint '${var.api_endpoint}' --b64-cluster-ca '${var.cluster_ca}' '${var.cluster_name}' \

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -20,9 +20,11 @@ locals {
   eks-node-userdata = <<USERDATA
 #!/bin/bash
 set -o xtrace
+id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
+ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
 /etc/eks/bootstrap.sh --apiserver-endpoint '${var.api_endpoint}' --b64-cluster-ca '${var.cluster_ca}' '${var.cluster_name}' \
 --kubelet-extra-args \
-  "--node-labels=cluster=${var.cluster_name},nodegroup=${var.node_group_name},nodetype=normal \
+  "--node-labels=cluster=${var.cluster_name},nodegroup=${var.node_group_name},instance-id=$id,ami-id=$ami \
    --cloud-provider=aws"
 ${var.extra_userdata}
 USERDATA

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -38,7 +38,7 @@ id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
 ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
 /etc/eks/bootstrap.sh --apiserver-endpoint '${var.api_endpoint}' --b64-cluster-ca '${var.cluster_ca}' '${var.cluster_name}' \
 --kubelet-extra-args \
-  "--node-labels=cluster=${var.cluster_name},nodegroup=${var.node_group_name},nodetype=spot \
+  "--node-labels=cluster=${var.cluster_name},nodegroup=${var.node_group_name},nodetype=spot,instance-id=$id,ami-id=$ami \
    --cloud-provider=aws"
 ${var.extra_userdata}
 USERDATA


### PR DESCRIPTION
# Why this change is needed
Add the same insatance and ami id labels to spot nodes

