### PR TITLE
Db sg

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -75,6 +75,7 @@ module "db" {
   db_name                = var.db_name
   rds_is_multi_az        = var.db_multi_az
   access_security_groups = [module.eks.node_security_group]
+  storage                = var.db_storage
 
   # Tags
   owner     = var.owner

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -74,7 +74,8 @@ module "db" {
   domain_name            = var.db_domain_name
   db_name                = var.db_name
   rds_is_multi_az        = var.db_multi_az
-  access_security_groups = [module.eks.node_security_group]
+  # extra_sg could be empty, so we run compact on the list to remove it if it is
+  access_security_groups = compact([module.eks.node_security_group, var.db_extra_sg])
   storage                = var.db_storage
 
   # Tags

--- a/infra/modules/database_layer/_variables.tf
+++ b/infra/modules/database_layer/_variables.tf
@@ -82,6 +82,10 @@ variable "db_port_num" {
   description = "Default port for database"
 }
 
+variable "extra_sg" {
+  default = ""
+}
+
 #--------------------------------------------------------------
 # Route53 DNS
 #--------------------------------------------------------------

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -75,6 +75,11 @@ variable "db_storage" {
   description = "Storage size in GB"
 }
 
+variable "db_extra_sg" {
+  default = ""
+  description = "enables an extra security group to access the RDS"
+}
+
 
 # VPC & subnets
 # ===========

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -70,6 +70,12 @@ variable "store_db_credentials" {
   description = "If true, db credentials will be stored in a kubernetes secret"
 }
 
+variable "db_storage" {
+  default     = "180"
+  description = "Storage size in GB"
+}
+
+
 # VPC & subnets
 # ===========
 variable "vpc_cidr" {


### PR DESCRIPTION
# Why this change is needed
Enables additional security groups to access the RDS (lambdas, extra ec2s etc)


# Negative effects of this change
supports use-cases were un-managed resources are deployed into the terraform managed vpc
