### PR TITLE
add missing crd to prometheus cleanup scripts

### DIFF
--- a/addons/prometheus.tf
+++ b/addons/prometheus.tf
@@ -77,6 +77,11 @@ command = "kubectl delete crd/servicemonitors.monitoring.coreos.com"
 
 provisioner "local-exec" {
 when = destroy
+command = "kubectl delete crd/podmonitors.monitoring.coreos.com"
+}
+
+provisioner "local-exec" {
+when = destroy
 command = "kubectl delete crd/alertmanagers.monitoring.coreos.com"
 }
 }


### PR DESCRIPTION
# Why this change is needed
deleting prometheus leaves an extra crd that isn't being cleaned up properly, causing re-installs to fail.


# Negative effects of this change
none
