### PR TITLE
add shared security group for alb's to use

### DIFF
--- a/infra/modules/eks/lb_sg.tf
+++ b/infra/modules/eks/lb_sg.tf
@@ -1,0 +1,31 @@
+resource "aws_security_group" "eks-lb" {
+  name        = "terraform-eks-lb"
+  description = "Security group for eks load balancers"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    "Name"                                      = "${var.cluster_name}-lb"
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+  }
+}

--- a/infra/modules/eks/worker_sg.tf
+++ b/infra/modules/eks/worker_sg.tf
@@ -58,3 +58,14 @@ resource "aws_security_group_rule" "eks-cluster-ingress-node-https" {
   type                     = "ingress"
 }
 
+# Connects workers to load balancers
+resource "aws_security_group_rule" "eks-node-ingress-cluster" {
+  description              = "Allow worker pods to receive communication from the load balancers"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks-node.id
+  source_security_group_id = aws_security_group.eks-lb.id
+  type                     = "ingress"
+}
+


### PR DESCRIPTION
# Why this change is needed
Creates a generic security group that can be used in alb-ingress-controller (or any other ingress controller) to reduce the proliferation of Security groups as per https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/682


# Negative effects of this change
Due to the reliance on the node security group this change can't be made in the addons folder, as it can potentially be used in other ingress-controllers I've chosen not to create it only when alb ingress controller is enabled.
