### PR TITLE
Add optional setting to enable rds storage autoscaling

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -257,7 +257,7 @@ db_storage = 500
 
 ## max_db_storage
 
-Enables storage autoscaling up to this amount, must be equal to or greater than db_storage if this value is 0, storage autoscaling is disabled.
+Enables storage autoscaling up to this amount, must be equal to or greater than db_storage, if this value is 0, storage autoscaling is disabled.
 
 When max_db_storage is any value other than 0, db_storage size is ignored by terraform to ensure it doesn't try and undto the autoscaling.
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -21,6 +21,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [db_multi_az](#db_multi_az)                                                                 | Infra                | No  | false |
 | [store_db_credentials](#store_db_credentials)                                               | Infra                | No  | false |
 | [db_storage](#db_storage)                                                                   | Infra                | No  | 180 |
+| [max_db_storage](#max_db_storage)                                                           | Infra                | No  | 0 |
 | [db_extra_sg](#db_extra_sg)                                                                 | Infra                | No  | "" |
 | [vpc_cidr](#vpc_cidr)                                                                       | Infra                | No  | "10.0.0.0/16" |
 | [public_subnet_cidrs](#public_subnet_cidrs)                                                 | Infra                | No  | ["10.0.0.0/22", "10.0.4.0/22", ["](#"10)10.0.8.0/22"] |
@@ -251,8 +252,20 @@ RDS storage size in GB, If this is increased it cannot be decreased.
 
 Example:
 ```
-store_db_credentials = 500
+db_storage = 500
 ```
+
+## max_db_storage
+
+Enables storage autoscaling up to this amount, must be equal to or greater than db_storage if this value is 0, storage autoscaling is disabled.
+
+When max_db_storage is any value other than 0, db_storage size is ignored by terraform to ensure it doesn't try and undto the autoscaling.
+
+Example:
+```
+max_db_storage = 500
+```
+
 
 ## db_extra_sg
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -77,6 +77,7 @@ module "db" {
   # extra_sg could be empty, so we run compact on the list to remove it if it is
   access_security_groups = compact([module.eks.node_security_group, var.db_extra_sg])
   storage                = var.db_storage
+  db_max_storage         = var.db_max_storage
 
   # Tags
   owner     = var.owner

--- a/infra/modules/database_layer/_variables.tf
+++ b/infra/modules/database_layer/_variables.tf
@@ -33,7 +33,7 @@ variable "storage" {
 }
 
 variable "db_max_storage" {
-  default = "0"
+  default     = "0"
   description = "Enables storage autoscaling up to this amount, disabled if 0"
 }
 

--- a/infra/modules/database_layer/_variables.tf
+++ b/infra/modules/database_layer/_variables.tf
@@ -32,6 +32,11 @@ variable "storage" {
   description = "Storage size in GB"
 }
 
+variable "db_max_storage" {
+  default = "0"
+  description = "Enables storage autoscaling up to this amount, disabled if 0"
+}
+
 variable "engine" {
   default     = "postgres"
   description = "Engine type: e.g. mysql, postgres"

--- a/infra/modules/database_layer/db.tf
+++ b/infra/modules/database_layer/db.tf
@@ -23,7 +23,7 @@ resource "aws_db_instance" "db" {
 
   # Instance parameters
   allocated_storage      = var.storage
-  max_allocated_storage = var.db_max_storage
+  max_allocated_storage  = var.db_max_storage
   storage_type           = "gp2"
   instance_class         = var.instance_class
   vpc_security_group_ids = [aws_security_group.rds.id]

--- a/infra/modules/database_layer/db.tf
+++ b/infra/modules/database_layer/db.tf
@@ -23,6 +23,7 @@ resource "aws_db_instance" "db" {
 
   # Instance parameters
   allocated_storage      = var.storage
+  max_allocated_storage = var.db_max_storage
   storage_type           = "gp2"
   instance_class         = var.instance_class
   vpc_security_group_ids = [aws_security_group.rds.id]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -75,6 +75,11 @@ variable "db_storage" {
   description = "Storage size in GB"
 }
 
+variable "db_max_storage" {
+  default = "0"
+  description = "Enables storage autoscaling up to this amount, disabled if 0"
+}
+
 variable "db_extra_sg" {
   default = ""
   description = "enables an extra security group to access the RDS"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -76,12 +76,12 @@ variable "db_storage" {
 }
 
 variable "db_max_storage" {
-  default = "0"
+  default     = "0"
   description = "Enables storage autoscaling up to this amount, disabled if 0"
 }
 
 variable "db_extra_sg" {
-  default = ""
+  default     = ""
   description = "enables an extra security group to access the RDS"
 }
 


### PR DESCRIPTION
# Why this change is needed
This change will enable rds storage autoscaling, which will reduce the chances of outages to apps on these clusters, by scaling rds storage instead of failing.


# Negative effects of this change
None, this change is entirely optional, leaving the max_db_storage to 0 will have no changes

I also fixed a small bug in doco for db_storage var.
