### PR TITLE
Multi AZ ASG

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -32,6 +32,11 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [default_worker_instance_type](#default_worker_instance_type)                               | Nodes                | No  | "" |
 | [group_enabled](#group_enabled)                                                             | Nodes                | No  | false |
 | [spot_nodes_enabled](#spot_nodes_enabled)                                                   | Nodes                | No  | false |
+| [min_nodes](#min_nodes)                                                                     | Nodes                | No  | 0 |
+| [desired_nodes](#desired_nodes)                                                             | Nodes                | No  | 0 |
+| [max_nodes](#max_nodes)                                                                     | Nodes                | No  | 0 |
+| [min_spot_nodes](#min_spot_nodes)                                                           | Nodes                | No  | 0 |
+| [max_spot_nodes](#max_spot_nodes)                                                           | Nodes                | No  | 0 |
 | [min_nodes_per_az](#min_nodes_per_az)                                                       | Nodes                | No  | 1 |
 | [desired_nodes_per_az](#desired_nodes_per_az)                                               | Nodes                | No  | 1 |
 | [max_nodes_per_az](#max_nodes_per_az)                                                       | Nodes                | No  | 2 |
@@ -366,25 +371,57 @@ Creates a second set of Autoscaling groups (one per AZ) that are configured to r
 
 You can tell pods to run on Spot nodes by setting an affinity for nodetype = spot
 
+## min_nodes
+
+The minimum number of on-demand nodes to run
+
+## desired_nodes
+
+Desired number of nodes only used when first launching the cluster afterwards you should scale with something like cluster-autoscaler.
+
+## max_nodes
+
+Max number of nodes you want to run, useful for controlling max cost of the cluster.
+
+## min_spot_nodes
+
+The minimum number of spot nodes to run.
+
+Good idea to keep this at 0, and allow cluster-autoscaler to create the nodes when you need them for processing jobs
+
+## max_spot_nodes
+
+Max number of spot you want to run, useful for controlling max cost of the cluster.
+
 ## min_nodes_per_az
+
+:warning: Deprecated, use [min_nodes](#min_nodes) instead :warning:
 
 The minimum number of on-demand nodes to run per Availability Zone, because of issues with how AWS handles autoscaling we currently deploy an ASG per availability zone
 
 ## desired_nodes_per_az
 
+:warning: Deprecated, use [desired_nodes](#desired_nodes) instead :warning:
+
 Desired number of nodes per AZ, only used when first launching the cluster afterwards you should scale with something like cluster-autoscaler.
 
 ## max_nodes_per_az
 
+:warning: Deprecated, use [max_nodes](#max_nodes) instead :warning:
+
 Max number of nodes you want to run per AZ, useful for controlling max cost of the cluster.
 
 ## min_spot_nodes_per_az
+
+:warning: Deprecated, use [min_spot_nodes](#min_spot_nodes) instead :warning:
 
 The minimum number of spot nodes to run per Availability Zone, because of issues with how AWS handles autoscaling we currently deploy an ASG per availability zone
 
 Good idea to keep this at 0, and allow cluster-autoscaler to create the nodes when you need them for processing jobs
 
 ## max_spot_nodes_per_az
+
+:warning: Deprecated, use [max_spot_nodes](#max_spot_nodes) instead :warning:
 
 Max number of spot you want to run per AZ, useful for controlling max cost of the cluster.
 

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -57,7 +57,6 @@ resource "aws_launch_template" "node" {
   }
 
   network_interfaces {
-    subnet_id = var.nodes_subnet_group
     associate_public_ip_address = false
     security_groups = [var.node_security_group]
     delete_on_termination = true
@@ -92,7 +91,6 @@ resource "aws_launch_template" "spot" {
   }
 
   network_interfaces {
-    subnet_id = var.nodes_subnet_group
     associate_public_ip_address = false
     security_groups = [var.node_security_group]
     delete_on_termination = true

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -46,7 +46,7 @@ USERDATA
 }
 
 resource "aws_launch_template" "node" {
-  count = (var.nodes_enabled ? 1 : 0) * length(var.nodes_subnet_group)
+  count = var.nodes_enabled ? 1 : 0
   name_prefix = var.cluster_name
   image_id = local.ami_id
   user_data = base64encode(local.eks-node-userdata)
@@ -57,7 +57,7 @@ resource "aws_launch_template" "node" {
   }
 
   network_interfaces {
-    subnet_id = var.nodes_subnet_group[count.index]
+    subnet_id = var.nodes_subnet_group
     associate_public_ip_address = false
     security_groups = [var.node_security_group]
     delete_on_termination = true
@@ -77,7 +77,7 @@ resource "aws_launch_template" "node" {
 }
 
 resource "aws_launch_template" "spot" {
-  count = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
+  count = var.spot_nodes_enabled ? 1 : 0
   name_prefix = var.cluster_name
   image_id = local.ami_id
   user_data = base64encode(local.eks-spot-userdata)
@@ -92,7 +92,7 @@ resource "aws_launch_template" "spot" {
   }
 
   network_interfaces {
-    subnet_id = var.nodes_subnet_group[count.index]
+    subnet_id = var.nodes_subnet_group
     associate_public_ip_address = false
     security_groups = [var.node_security_group]
     delete_on_termination = true

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -41,7 +41,7 @@ resource "aws_autoscaling_group" "nodes" {
   ]
 
   # Don't break cluster autoscaler
-  suspend_process = [AZrebalance]
+  suspended_processes = [AZrebalance]
 
   depends_on = [aws_launch_template.node]
 }
@@ -89,7 +89,7 @@ resource "aws_autoscaling_group" "spot_nodes" {
   ]
 
   # Don't break cluster autoscaler
-  suspend_process = [AZrebalance]
+  suspended_processes = [AZrebalance]
   
   depends_on = [aws_launch_template.spot]
 }

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -41,7 +41,7 @@ resource "aws_autoscaling_group" "nodes" {
   ]
 
   # Don't break cluster autoscaler
-  suspended_processes = ["AZrebalance"]
+  suspended_processes = ["AZRebalance"]
 
   depends_on = [aws_launch_template.node]
 }
@@ -89,7 +89,7 @@ resource "aws_autoscaling_group" "spot_nodes" {
   ]
 
   # Don't break cluster autoscaler
-  suspended_processes = ["AZrebalance"]
+  suspended_processes = ["AZRebalance"]
   
   depends_on = [aws_launch_template.spot]
 }

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -41,7 +41,7 @@ resource "aws_autoscaling_group" "nodes" {
   ]
 
   # Don't break cluster autoscaler
-  suspended_processes = [AZrebalance]
+  suspended_processes = ["AZrebalance"]
 
   depends_on = [aws_launch_template.node]
 }
@@ -89,7 +89,7 @@ resource "aws_autoscaling_group" "spot_nodes" {
   ]
 
   # Don't break cluster autoscaler
-  suspended_processes = [AZrebalance]
+  suspended_processes = ["AZrebalance"]
   
   depends_on = [aws_launch_template.spot]
 }

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -40,6 +40,9 @@ resource "aws_autoscaling_group" "nodes" {
     },
   ]
 
+  # Don't break cluster autoscaler
+  suspend_process = [AZrebalance]
+
   depends_on = [aws_launch_template.node]
 }
 
@@ -85,6 +88,9 @@ resource "aws_autoscaling_group" "spot_nodes" {
     },
   ]
 
+  # Don't break cluster autoscaler
+  suspend_process = [AZrebalance]
+  
   depends_on = [aws_launch_template.spot]
 }
 

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -3,7 +3,7 @@ resource "aws_autoscaling_group" "nodes" {
   desired_capacity = var.desired_nodes
   max_size         = var.max_nodes
   min_size         = var.min_nodes
-  name             = "${var.node_group_name}-${aws_launch_template.node[0].id}-nodes"
+  name             = "${var.node_group_name}-${aws_launch_template.node[0].id}-nodes-0"
   vpc_zone_identifier = var.nodes_subnet_group
 
   # Don't reset to default size every time terraform is applied
@@ -51,7 +51,7 @@ resource "aws_autoscaling_group" "spot_nodes" {
   desired_capacity = var.desired_nodes
   max_size         = var.max_spot_nodes
   min_size         = var.min_spot_nodes
-  name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot"
+  name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot-0"
   vpc_zone_identifier = var.nodes_subnet_group
 
   # Don't reset to default size every time terraform is applied

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,10 +1,10 @@
 resource "aws_autoscaling_group" "nodes" {
-  count            = var.nodes_enabled ? length(var.nodes_subnet_group) : 0
+  count            = var.nodes_enabled ? 1 : 0
   desired_capacity = var.desired_nodes
   max_size         = var.max_nodes
   min_size         = var.min_nodes
-  name             = "${var.node_group_name}-${aws_launch_template.node[count.index].id}-nodes-${count.index}"
-  vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
+  name             = "${var.node_group_name}-${aws_launch_template.node[0].id}-nodes"
+  vpc_zone_identifier = var.nodes_subnet_group
 
   # Don't reset to default size every time terraform is applied
   lifecycle {
@@ -13,14 +13,14 @@ resource "aws_autoscaling_group" "nodes" {
   }
 
   launch_template {
-    id      = element(aws_launch_template.node.*.id, count.index)
-    version = element(aws_launch_template.node.*.latest_version, count.index)
+    id      = aws_launch_template.node[0].id
+    version = aws_launch_template.node[0].latest_version
   }
 
   tags = [
     {
       key                 = "Name"
-      value               = "${var.cluster_name}-node-${count.index}"
+      value               = "${var.cluster_name}-node"
       propagate_at_launch = true
     },
     {
@@ -44,12 +44,12 @@ resource "aws_autoscaling_group" "nodes" {
 }
 
 resource "aws_autoscaling_group" "spot_nodes" {
-  count            = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
+  count            = var.spot_nodes_enabled ? 1 : 0
   desired_capacity = var.desired_nodes
   max_size         = var.max_spot_nodes
   min_size         = var.min_spot_nodes
-  name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
-  vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
+  name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot"
+  vpc_zone_identifier = var.nodes_subnet_group
 
   # Don't reset to default size every time terraform is applied
   lifecycle {
@@ -58,14 +58,14 @@ resource "aws_autoscaling_group" "spot_nodes" {
   }
 
   launch_template {
-    id      = element(aws_launch_template.spot.*.id, count.index)
-    version = element(aws_launch_template.spot.*.latest_version, count.index)
+    id      = aws_launch_template.spot[0].id
+    version = aws_launch_template.spot[0].latest_version
   }
 
   tags = [
     {
       key                 = "Name"
-      value               = "${var.cluster_name}-spot-${count.index}"
+      value               = "${var.cluster_name}-spot"
       propagate_at_launch = true
     },
     {

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -19,7 +19,27 @@ variable "group_enabled" {
 variable "spot_nodes_enabled" {
   default = false
 }
+variable "min_nodes" {
+  default = 0
+}
 
+variable "desired_nodes" {
+  default = 0
+}
+
+variable "max_nodes" {
+  default = 0
+}
+
+variable "min_spot_nodes" {
+  default = 0
+}
+
+variable "max_spot_nodes" {
+  default = 0
+}
+
+# nodes per az variables still work but are deprecated
 variable "min_nodes_per_az" {
   default = 1
 }


### PR DESCRIPTION
# Why this change is needed

Currently we create a single ASG per AZ and per nodetype, when using both spot and ondemand node types this means you will have 6 ASGs, this choice was made as ASG AZ rebalancing can mess with cluster autoscaler. 

This approach works, but raises additional issues:
- min number of nodes is min number of ASGs
- autoscaling from 0 can be a bit broken, cluster autoscaler will sometimes scale up one asg and leave other ones

# How this change works

To simplify deployments for new instances we now support new x_nodes variables:
- min_nodes
- max_nodes
- desired_nodes
- min_spot_nodes
- max_spot_nodes

The _nodes_per_az variables should still work if _nodes variable is >0 we use that, otherwise we will combine _nodes_per_az by the number of deployed AZs

# Negative effects of this change

This change has been tested without adding the new *_nodes variables, it will modify the values of your nodes-0 and spot-0 to be equivelant to the value of min_nodes_per_az * number of azs, it will remove the exra autoscaling groups, After this change has been made you should probably run the new roll_instances.sh script, to remove the old nodes in your asg which are deployed with an old version of the launch template that is pinned to a single AZ.


