### PR TITLE
Add kubewatch to monitor k8s resources

### DIFF
--- a/addons/kubewatch.tf
+++ b/addons/kubewatch.tf
@@ -1,0 +1,43 @@
+# BITNAMI KUBEWATCH CONTAINER HELM CHARTS
+# =======================================
+
+variable "kubewatch_enabled" {
+  description = "Kubewatch flag when enabled shall alert Slack about helm activities"
+  type        = bool
+  default = false
+}
+
+resource "kubernetes_namespace" "monitoring" {
+  count = var.kubewatch_enabled ? 1 : 0
+
+  metadata {
+    name = "monitoring"
+
+    labels = {
+      managed-by = "Terraform"
+    }
+  }
+}
+
+# Create the kubewatch operator, configure grafana dashboard ingress
+resource "helm_release" "kubewatch_operator" {
+  count      = var.kubewatch_enabled ? 1 : 0
+  name       = "kubewatch"
+  repository = "stable"
+  chart      = "kubewatch"
+  namespace  = "monitoring"
+
+  # Cleanup
+  provisioner "local-exec" {
+    when    = destroy
+    command = "helm delete --purge kubewatch"
+  }
+
+  depends_on = [
+    kubernetes_namespace.monitoring,
+    kubernetes_service_account.tiller,
+    kubernetes_cluster_role_binding.tiller_clusterrolebinding,
+    null_resource.helm_init_client
+    ]
+
+}

--- a/addons/kubewatch.tf
+++ b/addons/kubewatch.tf
@@ -159,7 +159,7 @@ resource "helm_release" "kubewatch_operator" {
 
   set {
     name  = "slack.enabled"
-    value = (var.kubewatch_slack_enabled != "") ? var.kubewatch_slack_enabled : false
+    value = var.kubewatch_slack_enabled
   }
 
   set {
@@ -174,7 +174,7 @@ resource "helm_release" "kubewatch_operator" {
 
   set {
     name  = "hipchat.enabled"
-    value = (var.kubewatch_hipchat_enabled != "") ? var.kubewatch_hipchat_enabled : ""
+    value = var.kubewatch_hipchat_enabled
   }
 
   set {
@@ -194,7 +194,7 @@ resource "helm_release" "kubewatch_operator" {
 
   set {
     name  = "mattermost.enabled"
-    value = (var.kubewatch_mattermost_enabled != "") ? var.kubewatch_mattermost_enabled : ""
+    value = var.kubewatch_mattermost_enabled
   }
 
   set {
@@ -214,7 +214,7 @@ resource "helm_release" "kubewatch_operator" {
 
   set {
     name  = "flock.enabled"
-    value = (var.kubewatch_flock_enabled != "") ? var.kubewatch_flock_enabled : ""
+    value = var.kubewatch_flock_enabled
   }
 
   set {
@@ -224,7 +224,7 @@ resource "helm_release" "kubewatch_operator" {
 
   set {
     name  = "webhook.enabled"
-    value = (var.kubewatch_webhook_enabled != "") ? var.kubewatch_webhook_enabled : ""
+    value = var.kubewatch_webhook_enabled
   }
 
   set {
@@ -234,42 +234,42 @@ resource "helm_release" "kubewatch_operator" {
 
   set {
     name  = "resourcesToWatch.deployment"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_deployment : false
+    value = var.kubewatch_resourcesToWatch_deployment
   }
 
   set {
     name  = "resourcesToWatch.replicationcontroller"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_replicationcontroller : false
+    value = var.kubewatch_resourcesToWatch_replicationcontroller
   }
 
   set {
     name  = "resourcesToWatch.replicaset"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_replicaset : false
+    value = var.kubewatch_resourcesToWatch_replicaset
   }
 
   set {
     name  = "resourcesToWatch.daemonset"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_daemonset : false
+    value = var.kubewatch_resourcesToWatch_daemonset
   }
 
   set {
     name  = "resourcesToWatch.services"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_services : false
+    value = var.kubewatch_resourcesToWatch_services
   }
 
   set {
     name  = "resourcesToWatch.pod"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_pod : false
+    value = var.kubewatch_resourcesToWatch_pod
   }
 
   set {
     name  = "resourcesToWatch.job"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_job : false
+    value = var.kubewatch_resourcesToWatch_job
   }
 
   set {
     name  = "resourcesToWatch.persistentvolume"
-    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_persistentvolume : false
+    value = var.kubewatch_resourcesToWatch_persistentvolume
   }
 
   depends_on = [

--- a/addons/kubewatch.tf
+++ b/addons/kubewatch.tf
@@ -4,7 +4,137 @@
 variable "kubewatch_enabled" {
   description = "Kubewatch flag when enabled shall alert Slack about helm activities"
   type        = bool
-  default = false
+  default     = false
+}
+
+variable "kubewatch_slack_enabled" {
+  description = "Push notification to Slack channel using slack token"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_slack_channel" {
+  description = "Slack channel to notify"
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_slack_token" {
+  description = "Slack bots token. Create using: https://my.slack.com/services/new/bot and invite the bot to your channel using: /join @botname"
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_hipchat_enabled" {
+  description = "Push notification to hipchat room"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_hipchat_room" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_hipchat_token" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_hipchat_url" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_mattermost_enabled" {
+  description = "Push notification to mattermost"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_mattermost_channel" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_mattermost_url" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_mattermost_username" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_flock_enabled" {
+  description = "Push notification to flock"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_flock_url" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_webhook_enabled" {
+  description = "Push notification to Webhook URL"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_webhook_url" {
+  type        = string
+  default     = ""
+}
+
+variable "kubewatch_resourcesToWatch_deployment" {
+  description = "Monitor k8s deployments"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_replicationcontroller" {
+  description = "Monitor k8s Replication Controller"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_replicaset" {
+  description = "Monitor k8s Replica Set"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_daemonset" {
+  description = "Monitor k8s Daemon Set"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_services" {
+  description = "Monitor k8s Services"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_pod" {
+  description = "Monitor k8s Pods"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_job" {
+  description = "Monitor k8s Jobs"
+  type        = bool
+  default     = false
+}
+
+variable "kubewatch_resourcesToWatch_persistentvolume" {
+  description = "Monitor k8s Persistent Volume"
+  type        = bool
+  default     = false
 }
 
 resource "kubernetes_namespace" "monitoring" {
@@ -19,7 +149,7 @@ resource "kubernetes_namespace" "monitoring" {
   }
 }
 
-# Create the kubewatch operator, configure grafana dashboard ingress
+# Create the kubewatch operator
 resource "helm_release" "kubewatch_operator" {
   count      = var.kubewatch_enabled ? 1 : 0
   name       = "kubewatch"
@@ -27,10 +157,119 @@ resource "helm_release" "kubewatch_operator" {
   chart      = "kubewatch"
   namespace  = "monitoring"
 
-  # Cleanup
-  provisioner "local-exec" {
-    when    = destroy
-    command = "helm delete --purge kubewatch"
+  set {
+    name  = "slack.enabled"
+    value = (var.kubewatch_slack_enabled != "") ? var.kubewatch_slack_enabled : false
+  }
+
+  set {
+    name  = "slack.channel"
+    value = (var.kubewatch_slack_enabled != "") ? var.kubewatch_slack_channel : ""
+  }
+
+  set {
+    name  = "slack.token"
+    value = (var.kubewatch_slack_enabled != "") ? var.kubewatch_slack_token : ""
+  }
+
+  set {
+    name  = "hipchat.enabled"
+    value = (var.kubewatch_hipchat_enabled != "") ? var.kubewatch_hipchat_enabled : ""
+  }
+
+  set {
+    name  = "hipchat.room"
+    value = (var.kubewatch_hipchat_enabled != "") ? var.kubewatch_hipchat_room : ""
+  }
+
+  set {
+    name  = "hipchat.token"
+    value = (var.kubewatch_hipchat_enabled != "") ? var.kubewatch_hipchat_token : ""
+  }
+
+  set {
+    name  = "hipchat.url"
+    value = (var.kubewatch_hipchat_enabled != "") ? var.kubewatch_hipchat_url : ""
+  }
+
+  set {
+    name  = "mattermost.enabled"
+    value = (var.kubewatch_mattermost_enabled != "") ? var.kubewatch_mattermost_enabled : ""
+  }
+
+  set {
+    name  = "mattermost.channel"
+    value = (var.kubewatch_mattermost_enabled != "") ? var.kubewatch_mattermost_channel : ""
+  }
+
+  set {
+    name  = "mattermost.url"
+    value = (var.kubewatch_mattermost_enabled != "") ? var.kubewatch_mattermost_url : ""
+  }
+
+  set {
+    name  = "mattermost.username"
+    value = (var.kubewatch_mattermost_enabled != "") ? var.kubewatch_mattermost_username : ""
+  }
+
+  set {
+    name  = "flock.enabled"
+    value = (var.kubewatch_flock_enabled != "") ? var.kubewatch_flock_enabled : ""
+  }
+
+  set {
+    name  = "flock.url"
+    value = (var.kubewatch_flock_enabled != "") ? var.kubewatch_flock_url : ""
+  }
+
+  set {
+    name  = "webhook.enabled"
+    value = (var.kubewatch_webhook_enabled != "") ? var.kubewatch_webhook_enabled : ""
+  }
+
+  set {
+    name  = "webhook.url"
+    value = (var.kubewatch_webhook_enabled != "") ? var.kubewatch_webhook_url : ""
+  }
+
+  set {
+    name  = "resourcesToWatch.deployment"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_deployment : false
+  }
+
+  set {
+    name  = "resourcesToWatch.replicationcontroller"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_replicationcontroller : false
+  }
+
+  set {
+    name  = "resourcesToWatch.replicaset"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_replicaset : false
+  }
+
+  set {
+    name  = "resourcesToWatch.daemonset"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_daemonset : false
+  }
+
+  set {
+    name  = "resourcesToWatch.services"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_services : false
+  }
+
+  set {
+    name  = "resourcesToWatch.pod"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_pod : false
+  }
+
+  set {
+    name  = "resourcesToWatch.job"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_job : false
+  }
+
+  set {
+    name  = "resourcesToWatch.persistentvolume"
+    value = (var.kubewatch_enabled != "") ? var.kubewatch_resourcesToWatch_persistentvolume : false
   }
 
   depends_on = [

--- a/docs/kubewatch.md
+++ b/docs/kubewatch.md
@@ -2,41 +2,14 @@
 [kubewatch](https://github.com/bitnami/charts/tree/master/upstreamed/kubewatch) is a Kubernetes watcher that currently publishes kubernetes resources notification in the EKS Cluster to Slack channel.
 
 
-## Kubewatch configuration file
-Use a kubewatch config map to define the configurable parameters for the kubewatch chart to watch kubernetes resources:
+## Kubewatch configurable parameters of the kubewatch chart
+Assign values to the kubewatch configurable parameters, to watch kubernetes resources:
 
-```YAML
-### kubewatch-configmap.yaml
-### ------------------------
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubewatch
-data:
-  .kubewatch.yaml: |
-    handler:
-      slack:
-        enabled: false  ## Disable (since we are using webhook url instead of specifying slack api token)
-      webhook:
-        enabled: true
-        url: "https://hooks.slack.com/services/<sample>/<test>/<token>"
-    resource:
-      deployment: true
-      replicationcontroller: false
-      replicaset: false
-      daemonset: false
-      services: true
-      pod: false
-      job: true
-      persistentvolume: true
-      namespace: false
-      secret: true
-      configmap: true
-      ingress: true
-```
+```text
+To monitor k8s deployments and push notification to a webhook url, set the following vars:
 
-# Execute command:
-
-``` bash
-kubectl apply -f kubewatch-configmap.yaml
+kubewatch_enabled=true
+kubewatch_webhook_enabled=true
+kubewatch_webhook_url="https://hooks.slack.com/services/<sample>/<test>/<token>"
+kubewatch_resourcesToWatch_deployment=true
 ```

--- a/docs/kubewatch.md
+++ b/docs/kubewatch.md
@@ -1,0 +1,42 @@
+# Kubewatch
+[kubewatch](https://github.com/bitnami/charts/tree/master/upstreamed/kubewatch) is a Kubernetes watcher that currently publishes kubernetes resources notification in the EKS Cluster to Slack channel.
+
+
+## Kubewatch configuration file
+Use a kubewatch config map to define the configurable parameters for the kubewatch chart to watch kubernetes resources:
+
+```YAML
+### kubewatch-configmap.yaml
+### ------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubewatch
+data:
+  .kubewatch.yaml: |
+    handler:
+      slack:
+        enabled: false  ## Disable (since we are using webhook url instead of specifying slack api token)
+      webhook:
+        enabled: true
+        url: "https://hooks.slack.com/services/<sample>/<test>/<token>"
+    resource:
+      deployment: true
+      replicationcontroller: false
+      replicaset: false
+      daemonset: false
+      services: true
+      pod: false
+      job: true
+      persistentvolume: true
+      namespace: false
+      secret: true
+      configmap: true
+      ingress: true
+```
+
+# Execute command:
+
+``` bash
+kubectl apply -f kubewatch-configmap.yaml
+```

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -90,6 +90,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [oauth_callback](#oauth_callback)"                                                          | Addons               | No  |  |
 | [metrics_server_enabled](#metrics_server_enabled)                                           | Addons               | No  | false |
 | [prometheus_enabled](#prometheus_enabled)                                                   | Addons               | No  | false |
+| [kubewatch_enabled](#kubewatch_enabled)                                                   | Addons               | No  | false |
 
 # Infra
 
@@ -684,9 +685,10 @@ Creates metrics server (not really any reason you don't want this)
 
 Enables prometheus for monitoring services (will deploy a grafana server at mgmt.$var.domain_name)
 
+## kubewatch_enabled
 
+Enables kubewatch watcher that publishes k8s cluster helm event notification in a slack channel.
 
- 
  
  
  

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -42,7 +42,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [spot_volume_size](#spot_volume_size)                                                       | Nodes                | No  | 20 |
 | [extra_userdata](#extra_userdata)                                                           | Nodes                | No  | <<USERDATA echo "" USERDATA |
 | [txt_owner_id](#txt_owner_id)                                                               | Addons               | No  | "AnOwnerId" |
-| [autoscaler-scale-down-unneeded-time](#autoscaler-scale-down-unneeded-time)                | Addons               | No  | "10m" |
+| [autoscaler-scale-down-unneeded-time](#autoscaler-scale-down-unneeded-time)                 | Addons               | No  | "10m" |
 | [alb_ingress_enabled](#alb_ingress_enabled)                                                 | Addons               | No  | false |
 | [cf_enable](#cf_enable)                                                                     | Addons               | No  | false |
 | [cf_dns_record](#cf_dns_record)                                                             | Addons               | No  | ows |
@@ -90,7 +90,30 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [oauth_callback](#oauth_callback)"                                                          | Addons               | No  |  |
 | [metrics_server_enabled](#metrics_server_enabled)                                           | Addons               | No  | false |
 | [prometheus_enabled](#prometheus_enabled)                                                   | Addons               | No  | false |
-| [kubewatch_enabled](#kubewatch_enabled)                                                   | Addons               | No  | false |
+| [kubewatch_enabled](#kubewatch_enabled)                                                     | Addons               | No  | false |
+| [kubewatch_slack_enabled](#kubewatch_slack_enabled)                                         | Addons               | No  | false |
+| [kubewatch_slack_channel](#kubewatch_slack_channel)                                         | Addons               | No  | "" |
+| [kubewatch_slack_token](#kubewatch_slack_token)                                             | Addons               | No  | "" |
+| [kubewatch_hipchat_enabled](#kubewatch_hipchat_enabled)                                     | Addons               | No  | false |
+| [kubewatch_hipchat_room](#kubewatch_hipchat_room)                                           | Addons               | No  | "" |
+| [kubewatch_hipchat_token](#kubewatch_hipchat_token)                                         | Addons               | No  | "" |
+| [kubewatch_hipchat_url](#kubewatch_hipchat_url)                                             | Addons               | No  | "" |
+| [kubewatch_mattermost_enabled](#kubewatch_mattermost_enabled)                               | Addons               | No  | false |
+| [kubewatch_mattermost_channel](#kubewatch_mattermost_channel)                               | Addons               | No  | "" |
+| [kubewatch_mattermost_url](#kubewatch_mattermost_url)                                       | Addons               | No  | "" |
+| [kubewatch_mattermost_username](#kubewatch_mattermost_username)                             | Addons               | No  | "" |
+| [kubewatch_flock_enabled](#kubewatch_flock_enabled)                                         | Addons               | No  | false |
+| [kubewatch_flock_url](#kubewatch_flock_url)                                                 | Addons               | No  | "" |
+| [kubewatch_webhook_enabled](#kubewatch_webhook_enabled)                                     | Addons               | No  | false |
+| [kubewatch_webhook_url](#kubewatch_webhook_url)                                             | Addons               | No  | "" |
+| [kubewatch_resourcesToWatch_deployment](#kubewatch_resourcesToWatch_deployment)             | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_replicationcontroller](#kubewatch_resourcesToWatch_replicationcontroller)      | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_replicaset](#kubewatch_resourcesToWatch_replicaset)             | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_daemonset](#kubewatch_resourcesToWatch_daemonset)               | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_services](#kubewatch_resourcesToWatch_services)                 | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_pod](#kubewatch_resourcesToWatch_pod)                           | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_job](#kubewatch_resourcesToWatch_job)                           | Addons               | No  | false |
+| [kubewatch_resourcesToWatch_persistentvolume](#kubewatch_resourcesToWatch_persistentvolume) | Addons               | No  | false |
 
 # Infra
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -689,18 +689,94 @@ Enables prometheus for monitoring services (will deploy a grafana server at mgmt
 
 Enables kubewatch watcher that publishes k8s cluster helm event notification in a slack channel.
 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+## kubewatch_slack_enabled
+
+Push kubewatch alert notification to Slack channel using slack token
+
+## kubewatch_slack_channel
+
+Slack channel to notify kubewatch alerts
+
+## kubewatch_slack_token
+
+Create slack bot token using: https://my.slack.com/services/new/bot and invite the bot to your channel using: /join @botname
+
+## kubewatch_hipchat_enabled
+
+Push kubewatch alert notification to hipchat room
+
+## kubewatch_hipchat_room
+
+Hipchat room name for kubewatch alert notifications
+
+## kubewatch_hipchat_token
+
+Hipchat room token to push notification to hipchat room
+
+## kubewatch_hipchat_url
+
+Hipchat URL
+
+## kubewatch_mattermost_enabled
+
+Push kubewatch alert notification to mattermost
+
+## kubewatch_mattermost_channel
+
+Mattermost Channel name
+
+## kubewatch_mattermost_url
+
+Mattermost channel URL
+
+## kubewatch_mattermost_username
+
+Mattermost username
+
+## kubewatch_flock_enabled
+
+Push kubewatch alert notification to flock
+
+## kubewatch_flock_url
+
+Flock URL
+
+## kubewatch_webhook_enabled
+
+Push kubewatch alert notification to Webhook URL
+
+## kubewatch_webhook_url
+
+Webhook URL
+
+## kubewatch_resourcesToWatch_deployment
+
+Kubewatch to monitor changes to k8s deployments
+
+## kubewatch_resourcesToWatch_replicationcontroller
+
+Kubewatch to monitor changes to k8s Replication Controller
+
+## kubewatch_resourcesToWatch_replicaset
+
+Kubewatch to monitor changes to k8s Replica Set
+
+## kubewatch_resourcesToWatch_daemonset
+
+Kubewatch to monitor changes to k8s Daemon Set
+
+## kubewatch_resourcesToWatch_services
+
+Kubewatch to monitor changes to k8s Services
+
+## kubewatch_resourcesToWatch_pod
+
+Kubewatch to monitor changes to k8s Pods
+
+## kubewatch_resourcesToWatch_job
+
+Kubewatch to monitor changes to k8s Jobs
+
+## kubewatch_resourcesToWatch_persistentvolume
+
+Kubewatch to monitor changes to k8s Persistent Volume


### PR DESCRIPTION
# Why this change is needed
- Existing k8s infra is using Flux cloud to alert slack when there is/are change/s in the datakube-apps repo. However, slack alert to notify when the change actually is being deployed in the eks cluster is missing. This PR adds bitnami's `kubewatch`, a Kubernetes watcher that currently publishes notification to Slack upon actual changes to k8s resources.

# Negative effects of this change
- The changes implemented as part of this PR is an add-on that by default is disabled and hence would not affect any existing infra setup.
