### PR TITLE
add coredns config map resource and patch update coredns config automatically on config update 

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -96,5 +96,6 @@ module "setup" {
   node_role_arn     = module.eks.node_role_arn
   user_role_arn     = module.eks.user_role_arn
   eks_service_user  = var.eks_service_user
+  db_hostname       = module.db.db_hostname
 }
 

--- a/infra/modules/setup/coredns_config.tf
+++ b/infra/modules/setup/coredns_config.tf
@@ -22,6 +22,9 @@ resource "kubernetes_config_map" "coredns_custom" {
     prometheus :9153
     proxy . /etc/resolv.conf
     cache 30
+    loop
+    reload
+    loadbalance
 }
 EOF
   }

--- a/infra/modules/setup/coredns_config.tf
+++ b/infra/modules/setup/coredns_config.tf
@@ -1,0 +1,32 @@
+resource "kubernetes_config_map" "coredns_custom" {
+  metadata {
+    name = "coredns-custom"
+    namespace = "kube-system"
+    labels = {
+      "eks.amazonaws.com/component": "coredns"
+      "k8s-app": "kube-dns"
+    }
+  }
+
+  data = {
+    Corefile = <<EOF
+.:53 {
+    errors
+    health
+    rewrite name database.local ${var.db_hostname}
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+      pods insecure
+      upstream
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    proxy . /etc/resolv.conf
+    cache 30
+}
+EOF
+  }
+
+  provisioner "local-exec" {
+    command = "kubectl patch deployment coredns -n kube-system --patch '{\"spec\":{\"template\":{\"spec\":{\"volumes\":[{\"configMap\":{\"items\":[{\"key\":\"Corefile\",\"path\":\"Corefile\"}],\"name\":\"coredns-custom\"},\"name\":\"config-volume\"}]}}}}'"
+  }
+}

--- a/infra/modules/setup/variables.tf
+++ b/infra/modules/setup/variables.tf
@@ -50,3 +50,9 @@ variable "eks_service_user" {
   description = "EKS Service account IAM user to manage kubernetes cluster. This will update kube-system aws-auth config mapUsers attribute if provided."
   default     = ""
 }
+
+variable "db_hostname" {
+  type = string
+  description = "DB hostname for coredns config"
+  default = ""
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -32,36 +32,6 @@ EOF
   sensitive = true
 }
 
-//output "coredns_config" {
-//  value = <<EOF
-//apiVersion: v1
-//data:
-//  Corefile: |
-//    .:53 {
-//        errors
-//        health
-//        rewrite name database.local ${module.db.db_hostname}
-//        kubernetes cluster.local in-addr.arpa ip6.arpa {
-//          pods insecure
-//          upstream
-//          fallthrough in-addr.arpa ip6.arpa
-//        }
-//        prometheus :9153
-//        proxy . /etc/resolv.conf
-//        cache 30
-//    }
-//kind: ConfigMap
-//metadata:
-//  labels:
-//    eks.amazonaws.com/component: coredns
-//    k8s-app: kube-dns
-//  name: coredns
-//  namespace: kube-system
-//
-//EOF
-//
-//}
-
 data "aws_caller_identity" "current" {
 }
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -32,35 +32,35 @@ EOF
   sensitive = true
 }
 
-output "coredns_config" {
-  value = <<EOF
-apiVersion: v1
-data:
-  Corefile: |
-    .:53 {
-        errors
-        health
-        rewrite name database.local ${module.db.db_hostname}
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-          pods insecure
-          upstream
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        proxy . /etc/resolv.conf
-        cache 30
-    }
-kind: ConfigMap
-metadata:
-  labels:
-    eks.amazonaws.com/component: coredns
-    k8s-app: kube-dns
-  name: coredns
-  namespace: kube-system
-
-EOF
-
-}
+//output "coredns_config" {
+//  value = <<EOF
+//apiVersion: v1
+//data:
+//  Corefile: |
+//    .:53 {
+//        errors
+//        health
+//        rewrite name database.local ${module.db.db_hostname}
+//        kubernetes cluster.local in-addr.arpa ip6.arpa {
+//          pods insecure
+//          upstream
+//          fallthrough in-addr.arpa ip6.arpa
+//        }
+//        prometheus :9153
+//        proxy . /etc/resolv.conf
+//        cache 30
+//    }
+//kind: ConfigMap
+//metadata:
+//  labels:
+//    eks.amazonaws.com/component: coredns
+//    k8s-app: kube-dns
+//  name: coredns
+//  namespace: kube-system
+//
+//EOF
+//
+//}
 
 data "aws_caller_identity" "current" {
 }


### PR DESCRIPTION
…ing local-exec provisioner

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add
Currently the coredns config is generated, but not automatically applied as a pod restart is required. 

We have automated a rolling deployment of the coredns pods after the config is updated by creating coredns custom config and apply rolling update using local-exec provisioner on resource config change. This will enable the database.local domain to be automatically configured on new deployments.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

The changes will roll update kubernetes cordns custom config on config change automatically. No manual step require to create and apply to coredns pod. There is a few seconds of outage first time as it recreates the coredns pod to apply the change.