### PR TITLE
Enable Auto-scaling from 0 #133

### DIFF
--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -38,6 +38,16 @@ resource "aws_autoscaling_group" "nodes" {
       value               = "true"
       propagate_at_launch = true
     },
+    {
+      key                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "k8s.io/cluster-autoscaler/node-template/label/nodetype"
+      value               = "ondemand"
+      propagate_at_launch = true
+    },
   ]
 
   # Don't break cluster autoscaler
@@ -84,6 +94,16 @@ resource "aws_autoscaling_group" "spot_nodes" {
     {
       key                 = "k8s.io/cluster-autoscaler/enabled"
       value               = "true"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "k8s.io/cluster-autoscaler/node-template/label/nodetype"
+      value               = "spot"
       propagate_at_launch = true
     },
   ]

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -58,7 +58,7 @@ resource "aws_autoscaling_group" "nodes" {
 
 resource "aws_autoscaling_group" "spot_nodes" {
   count            = var.spot_nodes_enabled ? 1 : 0
-  desired_capacity = var.desired_nodes
+  desired_capacity = var.min_spot_nodes
   max_size         = var.max_spot_nodes
   min_size         = var.min_spot_nodes
   name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot-0"
@@ -66,7 +66,8 @@ resource "aws_autoscaling_group" "spot_nodes" {
 
   # Don't reset to default size every time terraform is applied
   lifecycle {
-    ignore_changes        = [desired_capacity]
+    # commenting for testing
+    # ignore_changes        = [desired_capacity]
     create_before_destroy = true
   }
 

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -58,7 +58,7 @@ resource "aws_autoscaling_group" "nodes" {
 
 resource "aws_autoscaling_group" "spot_nodes" {
   count            = var.spot_nodes_enabled ? 1 : 0
-  desired_capacity = var.min_spot_nodes
+  desired_capacity = var.desired_nodes
   max_size         = var.max_spot_nodes
   min_size         = var.min_spot_nodes
   name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot-0"
@@ -66,8 +66,7 @@ resource "aws_autoscaling_group" "spot_nodes" {
 
   # Don't reset to default size every time terraform is applied
   lifecycle {
-    # commenting for testing
-    # ignore_changes        = [desired_capacity]
+    ignore_changes        = [desired_capacity]
     create_before_destroy = true
   }
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

This is an enhancement of #130 to support autoscaling from 0 for each node group type by adding require tags to ASG. This change will allow us to define ASG  min size and desire capacity set to zero and cluster-autoscaler can take care of scaling from 0.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No breaking changes. Added below tags to ASG:
- k8s.io/cluster-autoscaler/${var.cluster_name}
- k8s.io/cluster-autoscaler/node-template/label/nodetype
