### PR TITLE
set default value - waf_environment

### DIFF
--- a/addons/waf.tf
+++ b/addons/waf.tf
@@ -15,6 +15,7 @@ variable "waf_target_scope" {
 variable "waf_environment" {
   description = "The WAF environment name - used as part of resource name"
   type        = "string"
+  default     = ""
 }
 
 variable "waf_log_bucket" {
@@ -44,7 +45,7 @@ module "owasp_top_10_rules" {
 
   product_domain = "wafowasp"
   service_name   = "wafowasp"
-  environment    = "${var.waf_environment}"
+  environment    = (var.waf_enable) ? "${var.waf_environment}" : ""
   description    = "OWASP Top 10 rules for waf"
 
   target_scope      = (var.waf_enable) ? "${var.waf_target_scope}" : ""


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Set default value for waf_environment. This should be optional parameter if you don't want to configure WAF. Make this addon optional. 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

Fix the WAF configuration. No impact. 