### PR TITLE
commented set -e - will revisit a script later

### DIFF
--- a/scripts/roll_instances.sh
+++ b/scripts/roll_instances.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+# set -e
 
 # shellcheck disable=SC2178,SC2128
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

roll_instances script - comment set -e - will revisit a script later. Adding set -e doesn't ignore the error.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No impact