### PR TITLE
update condition logic for certificate_arn local variable

### DIFF
--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -113,8 +113,9 @@ resource "aws_acm_certificate_validation" "cert" {
 }
 
 locals {
-  # set certificate_arn to either the existing cert of the generated cert 
-  certificate_arn = (var.cf_certificate_arn != "") ? var.cf_certificate_arn : aws_acm_certificate_validation.cert[0].certificate_arn
+  # set certificate_arn to either the existing cert or the generated cert
+  generated_cert_arn = (var.cf_certificate_create) ? aws_acm_certificate_validation.cert[0].certificate_arn : ""
+  certificate_arn = (var.cf_certificate_arn != "" ) ? var.cf_certificate_arn : local.generated_cert_arn
 
   origin_domain = "${var.cf_origin_dns_record}.${var.domain_name}"
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

The cloudfront distribution addon fails to set local variable `certificate_arn` if `cf_certificate_arn = ""` and `cf_certificate_create=false`. This has broken sandbox pipeline.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

To mitigate the issue, the `certificate_arn` is set with similar logic in terraform-
if var.certificate_arn != "" then
   certificate_arn = var.certificate_arn
else if var.cf_certificate_create then
  certificate_arn = aws_acm_certificate_validation.cert[0].certificate_arn
else
  certificate_arn = ""