### PR TITLE
add EFS addon and documentation

### DIFF
--- a/addons/config/efs-provisioner.tpl
+++ b/addons/config/efs-provisioner.tpl
@@ -5,7 +5,7 @@
 ## Deploy environment label, e.g. dev, test, prod
 ##
 global:
-  deployEnv: dev
+  deployEnv: ${environment}
 ## Containers
 ##
 replicaCount: 1

--- a/addons/config/efs-provisioner.tpl
+++ b/addons/config/efs-provisioner.tpl
@@ -1,0 +1,74 @@
+#
+# Values for EFS provisioner service
+# https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
+#
+## Deploy environment label, e.g. dev, test, prod
+##
+global:
+  deployEnv: dev
+## Containers
+##
+replicaCount: 1
+revisionHistoryLimit: 10
+image:
+  repository: quay.io/external_storage/efs-provisioner
+  tag: v2.2.0-k8s1.12
+  pullPolicy: IfNotPresent
+busyboxImage:
+  repository: gcr.io/google_containers/busybox
+  tag: 1.27
+  pullPolicy: IfNotPresent
+## Deployment annotations
+##
+annotations: {}
+## Configure provisioner
+## https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs#deployment
+##
+efsProvisioner:
+  # If specified, use this DNS or IP to connect the EFS
+  dnsName: ${dnsName}
+  efsFileSystemId: ${efsFileSystemId}
+  awsRegion: ${awsRegion}
+  path: ${path}
+  provisionerName: example.com/aws-efs
+  storageClass:
+    name: efs
+    isDefault: false
+    gidAllocate:
+      enabled: true
+      gidMin: 40000
+      gidMax: 50000
+    reclaimPolicy: Delete
+    mountOptions: []
+      # - acregmin=3
+      # - acregmax=60
+## Enable RBAC
+## Leave serviceAccountName blank for the default name
+##
+rbac:
+  create: true
+  serviceAccountName: ""
+## Annotations to be added to deployment
+##
+podAnnotations: {
+  iam.amazonaws.com/role: ${iam_role_name}
+}
+## Node labels for pod assignment
+##
+nodeSelector: {}
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+# Tolerations for node tains
+tolerations: {}
+## Configure resources
+##
+resources: {}
+  # To specify resources, uncomment the following lines, adjust them as necessary,
+  # and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 200m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -3,6 +3,12 @@ variable "efs_enabled" {
     description = "Creates an encrypted EFS and connects it to the worker nodes"
 }
 
+variable "efs_pvc_namespace" {
+    default     = "Default"
+    type        = string
+    description = "The namespace to automatically create the efs persistant volume claim"
+}
+
 # Find Worker Node SG
 data "aws_security_group" "worker" {
   count = var.efs_enabled ? 1 : 0
@@ -96,6 +102,7 @@ resource "kubernetes_persistent_volume" "example" {
 resource "kubernetes_persistent_volume_claim" "efs" {
   metadata {
     name = "efs-persist"
+    namespace = var.efs_pvc_namespace
   }
   spec {
     access_modes = ["ReadWriteMany"]

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -13,6 +13,10 @@ variable "efs_pvc_namespace" {
 data "aws_security_group" "worker" {
   count = var.efs_enabled ? 1 : 0
   name  = "terraform-eks-eks-node"
+  tags = {
+    Name = "${var.cluster_name}-node"
+  }
+
 }
 
 # Find Network info

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -71,7 +71,7 @@ resource "aws_security_group" "ingress-efs" {
 resource "aws_efs_mount_target" "efs" {
   count = var.efs_enabled ? length(data.aws_subnet_ids.private[0].ids) : 0
   file_system_id  = aws_efs_file_system.efs[0].id
-  subnet_id       = data.aws_subnet_ids.private[0].ids[count.index]
+  subnet_id       = element(tolist(data.aws_subnet_ids.private[0].ids, count.index)
   security_groups = [aws_security_group.ingress-efs[0].id]
 
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -78,6 +78,7 @@ resource "aws_efs_mount_target" "efs" {
 
 # Create a shared disk to reference the EFS
 resource "kubernetes_persistent_volume" "example" {
+  count  = var.efs_enabled ? 1 :0
   metadata {
     name = "efs-persist"
     labels = {
@@ -100,6 +101,7 @@ resource "kubernetes_persistent_volume" "example" {
 }
 
 resource "kubernetes_persistent_volume_claim" "efs" {
+  count  = var.efs_enabled ? 1 :0
   metadata {
     name = "efs-persist"
     namespace = var.efs_pvc_namespace

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -86,7 +86,7 @@ resource "aws_efs_mount_target" "efs" {
 # We template the values instead of using a yaml, this should probably be cleaned up later to be consistent
 data "template_file" "efs-provisioner_config" {
   count          = var.efs_enabled ? 1 : 0
-  template = file("config/efs-provisioner.tpl")
+  template = file("${path.module}/config/efs-provisioner.tpl")
   vars = {
     efsFileSystemId = aws_efs_file_system.efs[0].id
     awsRegion       = var.region
@@ -98,7 +98,7 @@ data "template_file" "efs-provisioner_config" {
 
 # The efs-provisioner will create the k8s components we need
 resource "helm_release" "efs-provisioner" {
-  count          = var.efs_enabled ? 1 : 0
+  count     = var.efs_enabled ? 1 : 0
   name      = "efs-provisioner"
   namespace = "kube-system"
   chart     = "stable/efs-provisioner"

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -70,7 +70,7 @@ resource "aws_security_group" "ingress-efs" {
 
 resource "aws_efs_mount_target" "efs" {
   count = var.efs_enabled ? length(data.aws_subnet_ids.private[0].ids) : 0
-  file_system_id  = aws_efs_file_system.efs.id
+  file_system_id  = aws_efs_file_system.efs[0].id
   subnet_id       = element(data.aws_subnet_ids.private[0].ids, count.index)
   security_groups = [aws_security_group.ingress-efs[0].id]
 

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -108,27 +108,6 @@ resource "helm_release" "efs-provisioner" {
   depends_on = [aws_efs_mount_target.efs]
 }
 
-# EFS PVC using kubernetes provider
-resource "kubernetes_persistent_volume_claim" "efs" {
-  count  = var.efs_enabled ? 1 :0
-  metadata {
-    name      = "efs"
-    namespace = var.efs_pvc_namespace
-    annotations = {
-      "volume.beta.kubernetes.io/storage-class" = "efs" # this annotation has been deprecated but it appears to be necessary for cluster-autoscaler to function with PVC. Terraform might complain with some versions of k8s provider
-    }
-  }
-  spec {
-    storage_class_name = "efs"
-    access_modes       = ["ReadWriteMany"]
-    resources {
-      requests = {
-        storage = "1Mi"
-      }
-    }
-  }
-}
-
 # IAM policy 
 # At a minimum require read access to EFS  associated with user volumes
 # used by efs-provisioner helm chart

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -105,7 +105,7 @@ resource "helm_release" "efs-provisioner" {
   values = [
     data.template_file.efs-provisioner_config[0].rendered,
   ]
-  depends_on = [aws_efs_mount_target.user-storage]
+  depends_on = [aws_efs_mount_target.efs]
 }
 
 # EFS PVC using kubernetes provider
@@ -169,5 +169,5 @@ resource "aws_iam_role_policy" "efs-provisioner" {
   count  = var.efs_enabled ? 1 :0
   name = "${var.cluster_id}-efs-provisioner"
   role = aws_iam_role.efs-provisioner[0].id
-  policy = data.aws_iam_policy.efs-ro.policy
+  policy = data.aws_iam_policy.efs-ro[0].policy
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -93,6 +93,7 @@ data "template_file" "efs-provisioner_config" {
     path            = "/"
     dnsName         = aws_efs_file_system.efs[0].dns_name
     iam_role_name   = aws_iam_role.efs-provisioner[0].name
+    environment     = var.cluster_name
   }
 }
 

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -118,6 +118,6 @@ resource "kubernetes_persistent_volume_claim" "efs" {
       }
     }
     volume_name = "${kubernetes_persistent_volume.efs[0].metadata.0.name}"
-    storage_class_name = ""
+    storage_class_name = null
   }
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -4,7 +4,7 @@ variable "efs_enabled" {
 }
 
 # Find Worker Node SG
-data "aws_security_group" "selected" {
+data "aws_security_group" "worker" {
   count = var.efs_enabled ? 1 : 0
   name  = "${var.cluster_name}-node"
 }
@@ -47,7 +47,7 @@ resource "aws_security_group" "ingress-efs" {
 
    # NFS
    ingress {
-     security_groups = ["${data.aws_security_group.efs[0].id}"]
+     security_groups = [data.aws_security_group.worker[0].id]
      from_port       = 2049
      to_port         = 2049
      protocol        = "tcp"
@@ -55,7 +55,7 @@ resource "aws_security_group" "ingress-efs" {
 
    # Terraform removes the default rule
    egress {
-     security_groups = ["${data.aws_security_group.efs[0].id}"]
+     security_groups = [data.aws_security_group.worker[0].id]
      from_port       = 0
      to_port         = 0
      protocol        = "-1"

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -4,7 +4,7 @@ variable "efs_enabled" {
 }
 
 variable "efs_pvc_namespace" {
-    default     = "Default"
+    default     = "default"
     type        = string
     description = "The namespace to automatically create the efs persistant volume claim"
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -167,7 +167,7 @@ data "aws_iam_policy" "efs-ro" {
 
 resource "aws_iam_role_policy" "efs-provisioner" {
   count  = var.efs_enabled ? 1 :0
-  name = "${var.cluster_id}-efs-provisioner"
+  name = "${var.cluster_name}-efs-provisioner"
   role = aws_iam_role.efs-provisioner[0].id
   policy = data.aws_iam_policy.efs-ro[0].policy
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -1,0 +1,121 @@
+variable "efs_enabled" {
+    default     = false
+    description = "Creates an encrypted EFS and connects it to the worker nodes"
+}
+
+# Find Worker Node SG
+data "aws_security_group" "selected" {
+  count = var.efs_enabled ? 1 : 0
+  name  = "${var.cluster_name}-node"
+}
+
+# Find Network info
+data "aws_vpcs" "vpcs" {
+  count = var.efs_enabled ? 1 :0
+
+  tags = {
+    Name = "${var.cluster_name}-vpc"
+  }
+}
+
+data "aws_subnet_ids" "private" {
+  count  = var.efs_enabled ? 1 :0
+  vpc_id = element(tolist(data.aws_vpcs.vpcs[0].ids), 0)
+
+  tags = {
+    SubnetType = "Private"
+  }
+}
+
+resource "aws_efs_file_system" "efs" {
+  count          = var.efs_enabled ? 1 : 0
+  creation_token = var.cluster_name
+  encrypted      = true
+
+  tags = {
+    owner      = var.owner
+    cluster    = var.cluster_name
+    Created_by = "terraform"
+    Name       = "${var.cluster_name}_efs"
+  }
+}
+
+resource "aws_security_group" "ingress-efs" {
+   count  = var.efs_enabled ? 1 : 0
+   name   = "${var.cluster_name}-efs"
+   vpc_id = element(tolist(data.aws_vpcs.vpcs[0].ids), 0)
+
+   # NFS
+   ingress {
+     security_groups = ["${data.aws_security_group.efs[0].id}"]
+     from_port       = 2049
+     to_port         = 2049
+     protocol        = "tcp"
+   }
+
+   # Terraform removes the default rule
+   egress {
+     security_groups = ["${data.aws_security_group.efs[0].id}"]
+     from_port       = 0
+     to_port         = 0
+     protocol        = "-1"
+   }
+}
+
+resource "aws_efs_mount_target" "efs" {
+  count = var.efs_enabled ? length(data.aws_subnet_ids.private[0].ids) : 0
+  file_system_id  = aws_efs_file_system.efs.id
+  subnet_id       = element(data.aws_subnet_ids.private[0].ids, count.index)
+  security_groups = [aws_security_group.ingress-efs[0].id]
+
+}
+
+# Create a shared disk to reference the EFS
+resource "kubernetes_persistent_volume" "example" {
+  metadata {
+    name = "efs-persist"
+    labels = {
+      source = "Terraform"
+    }
+  }
+  spec {
+    capacity = {
+      # EFS scales based on usage so we set a high number we'll never actually hit
+      storage = "1P"
+    }
+    access_modes = ["ReadWriteMany"]
+    persistent_volume_source {
+      nfs {
+          server = aws_efs_mount_target.efs[0].dns_name
+          path = "/"
+      }
+    }
+  }
+}
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: efs-persist
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 11Gi
+
+resource "kubernetes_persistent_volume_claim" "efs" {
+  metadata {
+    name = "efs-persist"
+  }
+  spec {
+    access_modes = ["ReadWriteMany"]
+    resources {
+      requests = {
+        storage = "10G"
+      }
+    }
+    volume_name = "${kubernetes_persistent_volume.example.metadata.0.name}"
+  }
+}

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -113,6 +113,6 @@ resource "kubernetes_persistent_volume_claim" "efs" {
         storage = "10G"
       }
     }
-    volume_name = "${kubernetes_persistent_volume.example.metadata.0.name}"
+    volume_name = "${kubernetes_persistent_volume.example.metadata[0].0.name}"
   }
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -12,7 +12,7 @@ variable "efs_pvc_namespace" {
 # Find Worker Node SG
 data "aws_security_group" "worker" {
   count = var.efs_enabled ? 1 : 0
-  name  = "${var.cluster_name}-node"
+  name  = "terraform-eks-eks-node"
 }
 
 # Find Network info

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -71,7 +71,7 @@ resource "aws_security_group" "ingress-efs" {
 resource "aws_efs_mount_target" "efs" {
   count = var.efs_enabled ? length(data.aws_subnet_ids.private[0].ids) : 0
   file_system_id  = aws_efs_file_system.efs[0].id
-  subnet_id       = element(data.aws_subnet_ids.private[0].ids, count.index)
+  subnet_id       = data.aws_subnet_ids.private[0].ids[count.index]
   security_groups = [aws_security_group.ingress-efs[0].id]
 
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -93,18 +93,6 @@ resource "kubernetes_persistent_volume" "example" {
   }
 }
 
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: efs-persist
-spec:
-  storageClassName: ""
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 11Gi
-
 resource "kubernetes_persistent_volume_claim" "efs" {
   metadata {
     name = "efs-persist"

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -89,7 +89,7 @@ data "template_file" "efs-provisioner_config" {
   template = file("config/efs-provisioner.tpl")
   vars = {
     efsFileSystemId = aws_efs_file_system.efs[0].id
-    awsRegion       = var.aws_region
+    awsRegion       = var.region
     path            = "/"
     dnsName         = aws_efs_file_system.efs[0].dns_name
     iam_role_name   = aws_iam_role.efs-provisioner[0].name

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -118,5 +118,6 @@ resource "kubernetes_persistent_volume_claim" "efs" {
       }
     }
     volume_name = "${kubernetes_persistent_volume.efs[0].metadata.0.name}"
+    storage_class_name = ""
   }
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -71,7 +71,7 @@ resource "aws_security_group" "ingress-efs" {
 resource "aws_efs_mount_target" "efs" {
   count = var.efs_enabled ? length(data.aws_subnet_ids.private[0].ids) : 0
   file_system_id  = aws_efs_file_system.efs[0].id
-  subnet_id       = element(tolist(data.aws_subnet_ids.private[0].ids, count.index)
+  subnet_id       = element(tolist(data.aws_subnet_ids.private[0].ids, count.index))
   security_groups = [aws_security_group.ingress-efs[0].id]
 
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -77,7 +77,7 @@ resource "aws_efs_mount_target" "efs" {
 }
 
 # Create a shared disk to reference the EFS
-resource "kubernetes_persistent_volume" "example" {
+resource "kubernetes_persistent_volume" "efs" {
   count  = var.efs_enabled ? 1 :0
   metadata {
     name = "efs-persist"
@@ -113,6 +113,6 @@ resource "kubernetes_persistent_volume_claim" "efs" {
         storage = "10G"
       }
     }
-    volume_name = "${kubernetes_persistent_volume.example.metadata[0].0.name}"
+    volume_name = "${kubernetes_persistent_volume.efs[0].metadata.0.name}"
   }
 }

--- a/addons/efs.tf
+++ b/addons/efs.tf
@@ -71,7 +71,7 @@ resource "aws_security_group" "ingress-efs" {
 resource "aws_efs_mount_target" "efs" {
   count = var.efs_enabled ? length(data.aws_subnet_ids.private[0].ids) : 0
   file_system_id  = aws_efs_file_system.efs[0].id
-  subnet_id       = element(tolist(data.aws_subnet_ids.private[0].ids, count.index))
+  subnet_id       = element(tolist(data.aws_subnet_ids.private[0].ids), count.index)
   security_groups = [aws_security_group.ingress-efs[0].id]
 
 }

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -785,7 +785,7 @@ singleuser:
   storage:
     type: "static"
     static:
-      pvcName: "efs-persist"
+      pvcName: "efs"
       subPath: 'home/{username}'
   extraEnv:
     CHOWN_HOME: 'yes'

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -78,6 +78,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [dns_proportional_autoscaler_nodesPerReplica](#dns_proportional_autoscaler_nodesPerReplica) | Addons               | No  | 16 |
 | [dns_proportional_autoscaler_minReplica](#dns_proportional_autoscaler_minReplica)           | Addons               | No  | 2 |
 | [efs_enabled](#efs_enabled)                                                                 | Addons               | No  | false |
+| [efs_pvc_namespace](#efs_pvc_namespace)                                                     | Addons               | No  | default |
 | [external_dns_enabled](#external_dns_enabled)                                               | Addons               | No  | false |
 | [flux_enabled](#flux_enabled)                                                               | Addons               | No  | false |
 | [flux_git_repo_url](#flux_git_repo_url)                                                     | Addons               | No  | "git@github.com:opendatacube/datacube-k8s-eks |
@@ -675,6 +676,10 @@ singleuser:
   fsGid: 0
   cmd: "start-singleuser.sh"
 ```
+
+# efs_pvc_namespace
+
+Configure the Namespace you wish to create the EFS Persistant Volume Claim, this will have to match the namespace you are using to access the EFS volume, If you're using zero-to-jupyterhub you'll need to make this match the namespace you have deployed zero-to-jupyter in. 
 
 see [zero-to-jupyterhub docs](https://zero-to-jupyterhub.readthedocs.io/en/latest/amazon/efs_storage.html) for more info
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -77,6 +77,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [dns_proportional_autoscaler_coresPerReplica](#dns_proportional_autoscaler_coresPerReplica) | Addons               | No  | 256 |
 | [dns_proportional_autoscaler_nodesPerReplica](#dns_proportional_autoscaler_nodesPerReplica) | Addons               | No  | 16 |
 | [dns_proportional_autoscaler_minReplica](#dns_proportional_autoscaler_minReplica)           | Addons               | No  | 2 |
+| [efs_enabled](#efs_enabled)                                                                 | Addons               | No  | false |
 | [external_dns_enabled](#external_dns_enabled)                                               | Addons               | No  | false |
 | [flux_enabled](#flux_enabled)                                                               | Addons               | No  | false |
 | [flux_git_repo_url](#flux_git_repo_url)                                                     | Addons               | No  | "git@github.com:opendatacube/datacube-k8s-eks |
@@ -649,6 +650,33 @@ Scales core-dns depending on the number of cores / nodes useful when running lar
 ## dns_proportional_autoscaler_coresPerReplica
 ## dns_proportional_autoscaler_nodesPerReplica
 ## dns_proportional_autoscaler_minReplica
+
+## efs_enabled
+
+Setting this to true will create an encrypted EFS in your AWS account and configure it to be accessible from your workers as the pvc "efs-persist" 
+
+This is recommended on multi-az environments as cluster autoscaler will get confused with scaling nodes to fit users if they have EBS volumes (which are stored in a single AZ)
+
+You can configure zero to jupyterHub to use this efs like so:
+
+```
+singleuser:
+  image:
+    name: jupyter/base-notebook
+    tag: latest
+  storage:
+    type: "static"
+    static:
+      pvcName: "efs-persist"
+      subPath: 'home/{username}'
+  extraEnv:
+    CHOWN_HOME: 'yes'
+  uid: 0
+  fsGid: 0
+  cmd: "start-singleuser.sh"
+```
+
+see [zero-to-jupyterhub docs](https://zero-to-jupyterhub.readthedocs.io/en/latest/amazon/efs_storage.html) for more info
 
 
 ## external_dns_enabled

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -783,15 +783,8 @@ singleuser:
     name: jupyter/base-notebook
     tag: latest
   storage:
-    type: "static"
-    static:
-      pvcName: "efs"
-      subPath: 'home/{username}'
-  extraEnv:
-    CHOWN_HOME: 'yes'
-  uid: 0
-  fsGid: 0
-  cmd: "start-singleuser.sh"
+    dynamic:
+      storageClass: "efs"
 ```
 
 # efs_pvc_namespace

--- a/scripts/roll_instances.sh
+++ b/scripts/roll_instances.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+# set -e
 
 # shellcheck disable=SC2178,SC2128
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

This change creates an addon for EFS storage, this is required for running zero-to-jupyterhub in a multi-az deployment as cluster autoscaler will struggle to connect the AZ with the disks users are using. Instead we create a single shared EFS volume and give each user their own folder in this disk, which is mounted to their jupyterhub container.

This PR should close #120 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

I've tested enabling / disabling
and running alongside existing Z2JH user pods with gp2 pvcs

If you have existing user pvcs (gp2) you'll have to delete them for a new efs pvc to be created for that user.
