### PR TITLE
Fix cf log bucket

### DIFF
--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -123,9 +123,8 @@ locals {
   default_alias = ["${var.cf_dns_record}.${var.domain_name}"]
   alias         = compact(concat(local.default_alias, var.cf_custom_aliases))
 
-  # Get a bucket name without extention: .s3.amazonaws.com
-  log_bucket = element(split("\\.s3\\.amazonaws\\.com",var.cf_log_bucket), 0)
-  # is_cf_log_bucket_with_extention = length(regexall("^.*s3\\.amazonaws\\.com$",var.cf_log_bucket)) > 0
+  # Get a bucket name without an extention: .s3.amazonaws.com
+  log_bucket = element(split(".s3.amazonaws.com",var.cf_log_bucket), 0)
 }
 
 # create a policy document for the log bucket
@@ -159,7 +158,9 @@ resource "aws_s3_bucket" "cloudfront_log_bucket" {
   region = var.region
   acl    = "private"
   policy = data.aws_iam_policy_document.cloudfront_log_bucket_policy_doc[0].json
-  force_destroy = true
+
+  # Needed if you want to delete the bucket
+  # force_destroy = true
 
   server_side_encryption_configuration {
     rule {

--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "cloudfront_log_bucket_policy_doc" {
     ]
 
     resources = [
-      "arn:aws:s3:::dea-cloudfront-logs-test.s3.amazonaws.com"
+      "arn:aws:s3:::${var.cf_log_bucket}"
     ]
   }
 }
@@ -225,7 +225,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
   }
 
   logging_config {
-    bucket = var.cf_log_bucket
+    bucket = "${var.cf_log_bucket}.s3.amazonaws.com"
     prefix = "${var.cluster_name}_${terraform.workspace}_cf"
   }
 

--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -35,7 +35,7 @@ variable "cf_log_bucket" {
 }
 
 variable "cf_log_bucket_create" {
-  default = true
+  default = false
 }
 
 # Optional tuning variables
@@ -126,7 +126,7 @@ locals {
 
 # Create an S3 bucket to store cf logs
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
-  count  = (var.cf_log_bucket_create && var.cf_enable) ? 1 : 0
+  count  = (var.cf_log_bucket_create) ? 1 : 0
   bucket = var.cf_log_bucket
   region = var.region
   acl    = "private"
@@ -146,7 +146,7 @@ resource "aws_s3_bucket" "cloudfront_log_bucket" {
 
 # create a policy document for the log bucket
 data "aws_iam_policy_document" "cloudfront_log_bucket_policy_doc" {
-  count  = (var.cf_log_bucket_create && var.cf_enable) ? 1 : 0
+  count  = (var.cf_log_bucket_create) ? 1 : 0
   statement {
     effect = "Allow"
 
@@ -170,7 +170,7 @@ data "aws_iam_policy_document" "cloudfront_log_bucket_policy_doc" {
 
 # Attach the policy to the log bucket
 resource "aws_s3_bucket_policy" "cloudfront_log_bucket_policy" {
-  count  = (var.cf_log_bucket_create && var.cf_enable) ? 1 : 0
+  count  = (var.cf_log_bucket_create) ? 1 : 0
   bucket = aws_s3_bucket.cloudfront_log_bucket[0].id
   policy = data.aws_iam_policy_document.cloudfront_log_bucket_policy_doc[0].json
 }

--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -122,6 +122,8 @@ locals {
   # Creates a basic cloudfront disribution with a custom (i.e. not S3) origin
   default_alias = ["${var.cf_dns_record}.${var.domain_name}"]
   alias         = compact(concat(local.default_alias, var.cf_custom_aliases))
+
+  is_cf_log_bucket_with_extention = length(regexall("*.s3.amazonaws.com$",var.cf_log_bucket)) > 0
 }
 
 # create a policy document for the log bucket
@@ -221,7 +223,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
   }
 
   logging_config {
-    bucket = "${var.cf_log_bucket}.s3.amazonaws.com"
+    bucket = local.is_cf_log_bucket_with_extention ? var.cf_log_bucket : "${var.cf_log_bucket}.s3.amazonaws.com"
     prefix = "${var.cluster_name}_${terraform.workspace}_cf"
   }
 

--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -123,7 +123,7 @@ locals {
   default_alias = ["${var.cf_dns_record}.${var.domain_name}"]
   alias         = compact(concat(local.default_alias, var.cf_custom_aliases))
 
-  is_cf_log_bucket_with_extention = length(regexall("*.s3.amazonaws.com$",var.cf_log_bucket)) > 0
+  is_cf_log_bucket_with_extention = length(regexall("*\\.s3\\.amazonaws\\.com$",var.cf_log_bucket)) > 0
 }
 
 # create a policy document for the log bucket

--- a/addons/cloudfront_distribution.tf
+++ b/addons/cloudfront_distribution.tf
@@ -123,7 +123,7 @@ locals {
   default_alias = ["${var.cf_dns_record}.${var.domain_name}"]
   alias         = compact(concat(local.default_alias, var.cf_custom_aliases))
 
-  is_cf_log_bucket_with_extention = length(regexall("*\\.s3\\.amazonaws\\.com$",var.cf_log_bucket)) > 0
+  is_cf_log_bucket_with_extention = length(regexall("^.*s3\\.amazonaws\\.com$",var.cf_log_bucket)) > 0
 }
 
 # create a policy document for the log bucket

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -541,7 +541,7 @@ will create a certificate in us-east-1 for ows.consoto.org
 
 S3 Bucket to store cloudfront logs
 
-Support both the form `bucketname` or `bucketname.s3.amazonaws.com` 
+Support both the form `<bucketname>` or `<bucketname>.s3.amazonaws.com` 
 
 If `cf_log_bucket_create` is set to `false`, this bucket must already exist in your AWS account and be configured to allow cloudfront to write logs to it.
 see [Cloudfront Access Logs Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html)

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -226,19 +226,6 @@ Example:
 domain_name = "sandbox.business.com"
 ```
 
-## cloudfront_log_bucket
-
-S3 Bucket to store cloudfront logs
-
-Must currently be in the form `bucketname.s3.amazonaws.com` 
-
-This bucket must already exist in your AWS account, and be configured to allow cloudfront to write logs to it
-
-Example:
-```
-cloudfront_log_bucket = "sandbox-logs.s3.amazonaws.com"
-```
-
 ## create_certificate
 
 If this is set to `true` a wildcard certificate of `*.${var.domain_name}` will be created and validated for you.
@@ -550,18 +537,23 @@ cf_certificate_create = true
 
 will create a certificate in us-east-1 for ows.consoto.org
 
-## cf_log_bucket
+## cloudfront_log_bucket
 
-The bucket to send cloudfront logs to must be in the long form, this bucket must already exist
+S3 Bucket to store cloudfront logs
 
+Support both the form `bucketname` or `bucketname.s3.amazonaws.com` 
+
+If `cf_log_bucket_create` is set to `false`, this bucket must already exist in your AWS account and be configured to allow cloudfront to write logs to it.
+see [Cloudfront Access Logs Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html)
+
+Example:
 ```
-cf_log_bucket = "cloudfront-logs.s3.amazonaws.com"
-cf_log_bucket_create = false
+cloudfront_log_bucket = "cloudfront-logs.s3.amazonaws.com"
 ```
 
 ## cf_log_bucket_create
 
-Do not use (see issue #85)
+Creates a cloudfront distribution log bucket.
 
 ## cf_origin_protocol_policy
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Cloudfront distribution logging configuration is currently in broken state and not delivering any logs. This PR is to fix below two issues -
- bucket configuration - missing bucket policy
- cf logging configuration 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No Imapact. Enable logging functionality - cloudfront distribution. 

How to use:
cf_log_bucket_create = true   # Flag to create a bucket
cf_log_bucket = <bucketname> # Bucket name use for forwarding cf logs to

If cf_log_bucket_create = false, then must configure bucket as per cf guidelines.