### PR TITLE
#143 Allow injection of postgres version

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -305,6 +305,17 @@ db_extra_sg = "sg-01b1c252cbf21c553"
 db_extra_sg = "sg-01b203b405b608b80"
 ```
 
+## db_engine_version
+
+Explicitly sets engine specific version for the database used. OpenDataCube / OpenWebServices typically uses PostgreSQL RDS instances and has been successfully tested with 9.6.11, 10.10 and 11.5 versions available on AWS. Terraform does not automatically allow [major version upgrades](https://www.terraform.io/docs/providers/aws/r/db_instance.html#allow_major_version_upgrade). PostGIS extensions if used have to be upgraded in tandem using [Terraform mechanisms](https://www.terraform.io/docs/providers/postgresql/r/postgresql_extension.html).
+
+Example:
+```
+{
+  postgres = "11.5"
+}
+```
+
 ## vpc_cidr
 
 The network CIDR you wish to use for this VPC, if you have organisational requirements to configure peering etc this is necessary. Otherwise the defaults are sane for most use-cases.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -24,6 +24,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [db_storage](#db_storage)                                                                   | Infra                | No  | 180 |
 | [max_db_storage](#max_db_storage)                                                           | Infra                | No  | 0 |
 | [db_extra_sg](#db_extra_sg)                                                                 | Infra                | No  | "" |
+| [db_engine_version](#db_engine_version)                                                     | Infra                | No  | "11.5" |
 | [vpc_cidr](#vpc_cidr)                                                                       | Infra                | No  | "10.0.0.0/16" |
 | [public_subnet_cidrs](#public_subnet_cidrs)                                                 | Infra                | No  | ["10.0.0.0/22", "10.0.4.0/22", ["](#"10)10.0.8.0/22"] |
 | [private_subnet_cidrs](#private_subnet_cidrs)                                               | Infra                | No  | ["10.0.32.0/19", "10.0.64.0/19", ["](#"10)10.0.96.0/19"] |

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -24,7 +24,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [db_storage](#db_storage)                                                                   | Infra                | No  | 180 |
 | [max_db_storage](#max_db_storage)                                                           | Infra                | No  | 0 |
 | [db_extra_sg](#db_extra_sg)                                                                 | Infra                | No  | "" |
-| [db_engine_version](#db_engine_version)                                                     | Infra                | No  | "11.5" |
+| [db_engine_version](#db_engine_version)                                                     | Infra                | No  | "9.6.11" |
 | [vpc_cidr](#vpc_cidr)                                                                       | Infra                | No  | "10.0.0.0/16" |
 | [public_subnet_cidrs](#public_subnet_cidrs)                                                 | Infra                | No  | ["10.0.0.0/22", "10.0.4.0/22", ["](#"10)10.0.8.0/22"] |
 | [private_subnet_cidrs](#private_subnet_cidrs)                                               | Infra                | No  | ["10.0.32.0/19", "10.0.64.0/19", ["](#"10)10.0.96.0/19"] |

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -81,6 +81,9 @@ module "db" {
   storage                = var.db_storage
   db_max_storage         = var.db_max_storage
 
+  #Engine version
+  engine_version         = var.db_engine_version
+
   # Tags
   owner     = var.owner
   cluster   = var.cluster_name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -97,7 +97,7 @@ variable "db_extra_sg" {
 
 variable "db_engine_version" {
   default = {
-    postgres = "11.5"
+    postgres = "9.6.11"
   }
   description = "PostgreSQL engine version used for initialization in specific deployments"
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_name" {
 }
 
 variable "cluster_version" {
-  type = "string"
+  type        = "string"
   description = "EKS Cluster version to use"
 }
 
@@ -63,7 +63,7 @@ variable "create_certificate" {
 
 # Database
 variable "db_instance_enabled" {
-  default = true
+  default     = true
   description = "Create an RDS postgres instance for use by the datacube"
 }
 
@@ -93,6 +93,13 @@ variable "db_max_storage" {
 variable "db_extra_sg" {
   default     = ""
   description = "enables an extra security group to access the RDS"
+}
+
+variable "db_engine_version" {
+  default = {
+    postgres = "11.5"
+  }
+  description = "PostgreSQL engine version used for initialization in specific deployments"
 }
 
 


### PR DESCRIPTION
# Why this change is needed
Addresses injection of DB version via TF variables


# Negative effects of this change
Needs to be tested in dev cluster builds before being upgraded in prod since the upgrade path from 9.6 -> 11.5 is not straight-forward. Also needed will be postgis version matches and in-tandem upgrades. This has been captured in #144.
