### PR TITLE
Enable DNS query logging

### DIFF
--- a/infra/modules/setup/coredns_config.tf
+++ b/infra/modules/setup/coredns_config.tf
@@ -11,6 +11,7 @@ resource "kubernetes_config_map" "coredns_custom" {
   data = {
     Corefile = <<EOF
 .:53 {
+    log
     errors
     health
     rewrite name database.local ${var.db_hostname}


### PR DESCRIPTION
## Why this change is needed
- To verify if DNS queries are being received/processed by CoreDNS, the log plugin is added to the CoreDNS configuration (aka Corefile).

## Negative effects of this change
- Side effects are not expected with DNS query logging
