### PR TITLE
Service role

### DIFF
--- a/addons/service_account_roles.tf
+++ b/addons/service_account_roles.tf
@@ -1,0 +1,48 @@
+variable "service_account_roles" {
+  type        = "list"
+  default     = []
+  description = "Specify custom IAM roles that can be used by pods on the k8s cluster"
+}
+
+resource "aws_iam_openid_connect_provider" "example" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = []
+  url             = "${data.aws_eks_cluster.eks.identity.0.oidc.0.issuer}"
+}
+
+data "aws_iam_policy_document" "trust_policy" {
+  count     = length(var.service_account_roles)
+  statement {
+    sid = "1"
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    # List of users
+    principals {
+      type = "Federated"
+      identifiers = ["${aws_iam_openid_connect_provider.example.arn}"]
+  }
+
+    # Enforce MFA
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.example.url, "https://", "")}:sub"
+      values   = [
+        "system:serviceaccount:${var.service_account_roles[count.index].service_account_namespace}:${var.service_account_roles[count.index].service_account_name}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "service_account_role" {
+  count              = length(var.service_account_roles)
+  name               = "${var.cluster_name}-${var.service_account_roles[count.index].name}"
+  assume_role_policy = data.aws_iam_policy_document.trust_policy[count.index].json
+}
+
+resource "aws_iam_role_policy" "service_account_role_policy" {
+  count  = length(var.service_account_roles)
+  name   = "${var.cluster_name}-${var.service_account_roles[count.index].name}"
+  role   = aws_iam_role.service_account_role[count.index].id
+  policy = var.service_account_roles[count.index].policy
+}

--- a/addons/service_account_roles.tf
+++ b/addons/service_account_roles.tf
@@ -15,7 +15,7 @@ variable "service_account_roles" {
   # ]
 }
 
-resource "aws_iam_openid_connect_provider" "example" {
+resource "aws_iam_openid_connect_provider" "identity_provider" {
   count     = (length(var.service_account_roles) > 0) ? 1 : 0
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = []
@@ -31,12 +31,12 @@ data "aws_iam_policy_document" "trust_policy" {
 
     principals {
       type = "Federated"
-      identifiers = ["${aws_iam_openid_connect_provider.example[0].arn}"]
+      identifiers = ["${aws_iam_openid_connect_provider.identity_provider[0].arn}"]
     }
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(aws_iam_openid_connect_provider.example[0].url, "https://", "")}:sub"
+      variable = "${replace(aws_iam_openid_connect_provider.identity_provider[0].url, "https://", "")}:sub"
       values   = [
         "system:serviceaccount:${var.service_account_roles[count.index].service_account_namespace}:${var.service_account_roles[count.index].service_account_name}"
       ]

--- a/addons/service_account_roles.tf
+++ b/addons/service_account_roles.tf
@@ -29,13 +29,11 @@ data "aws_iam_policy_document" "trust_policy" {
 
     actions = ["sts:AssumeRoleWithWebIdentity"]
 
-    # List of users
     principals {
       type = "Federated"
       identifiers = ["${aws_iam_openid_connect_provider.example[0].arn}"]
-  }
+    }
 
-    # Enforce MFA
     condition {
       test     = "StringEquals"
       variable = "${replace(aws_iam_openid_connect_provider.example[0].url, "https://", "")}:sub"

--- a/addons/service_account_roles.tf
+++ b/addons/service_account_roles.tf
@@ -2,6 +2,17 @@ variable "service_account_roles" {
   type        = "list"
   default     = []
   description = "Specify custom IAM roles that can be used by pods on the k8s cluster"
+  # service_account_roles = [
+  #   {
+  #       name  = "foo"
+  #       service_account_namespace = "foo-sa"
+  #       service_account_name = "foo-sa"
+  #       policy = <<-EOF
+  #       IAMPolicyDocument
+  #         WithIdents
+  #       EOF
+  #   }
+  # ]
 }
 
 resource "aws_iam_openid_connect_provider" "example" {

--- a/addons/service_account_roles.tf
+++ b/addons/service_account_roles.tf
@@ -6,7 +6,7 @@ variable "service_account_roles" {
   #   {
   #       name  = "foo"
   #       service_account_namespace = "foo-sa"
-  #       service_account_name = "foo-sa"
+  #       service_account_name = "foo-sa"    # put "*" to scope a role to an entire namespace
   #       policy = <<-EOF
   #       IAMPolicyDocument
   #         WithIdents
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "trust_policy" {
     }
 
     condition {
-      test     = "StringEquals"
+      test     = (var.service_account_roles[count.index].service_account_name != "*") ? "StringEquals": "StringLike"
       variable = "${replace(aws_iam_openid_connect_provider.identity_provider[0].url, "https://", "")}:sub"
       values   = [
         "system:serviceaccount:${var.service_account_roles[count.index].service_account_namespace}:${var.service_account_roles[count.index].service_account_name}"

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -725,7 +725,7 @@ service_account_roles = [
   {
     name = "eks-wms"
     service_account_namespace = "foo-sa"
-    service_account_name = "foo"
+    service_account_name = "foo"   # put "*" to scope a role to an entire namespace
     policy = <<-EOF
       {
         "Version": "2012-10-17",

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -704,9 +704,9 @@ Then configure a pod to assumes the IAM role using `sts:AssumeRoleWithWebIdentit
 
 Limitation:
 Currently it doesn't pass AWS creds to pods directly,
-- Extra role handling logic required to get a temporary assume role based session using boto3 AWS SDK
-- Needed a logic to auto refersh session for a long leaved service
-- Needed a logic to export creds to support third party tools/library
+- Extra role handling logic required to get a temporary credentials using assume role with web identity based session - ideally using boto3 AWS SDK
+- Needed a logic to auto refresh session for a long lived service
+- Needed a logic to export credentials to support third party tools/library
 
 See [IAM role for service-account](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) for more details
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -122,6 +122,7 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [kubewatch_resourcesToWatch_pod](#kubewatch_resourcesToWatch_pod)                           | Addons               | No  | false |
 | [kubewatch_resourcesToWatch_job](#kubewatch_resourcesToWatch_job)                           | Addons               | No  | false |
 | [kubewatch_resourcesToWatch_persistentvolume](#kubewatch_resourcesToWatch_persistentvolume) | Addons               | No  | false |
+| [service_account_roles](#service_accout_roles)                                              | Addons               | No  | [] |
 
 # Infra
 
@@ -670,6 +671,61 @@ A list of roles that can be used by kube2iam, roles will be prefixedd with the c
 custom_kube2iam_roles = [
   {
     name = "eks-wms"
+    policy = <<-EOF
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["S3:ListBucket"],
+            "Resource": [
+              "arn:aws:s3:::dea-public-data"
+            ]
+          },
+          {
+            "Effect": "Allow",
+            "Action": ["S3:GetObject"],
+            "Resource": [
+              "arn:aws:s3:::dea-public-data/*"
+            ]
+          }
+        ]
+      }
+    EOF
+  }
+]
+```
+
+## service_account_roles
+
+A list of roles that can be used by service-account, roles will be prefixed with the cluster name, and can be assigned to service-account via the annotation. 
+Once you configure service-account, you can assign a service-account to pod. This will pass `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables to the pod.
+Then configure a pod to assumes the IAM role using `sts:AssumeRoleWithWebIdentity`.
+
+Limitation:
+Currently it doesn't pass AWS creds to pods directly,
+- Extra role handling logic required to get a temporary assume role based session using boto3 AWS SDK
+- Needed a logic to auto refersh session for a long leaved service
+- Needed a logic to export creds to support third party tools/library
+
+See [IAM role for service-account](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) for more details
+
+```
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: foo-sa
+      namespace: foo
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
+````
+
+```
+service_account_roles = [
+  {
+    name = "eks-wms"
+    service_account_namespace = "foo-sa"
+    service_account_name = "foo"
     policy = <<-EOF
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Provision OpenID Connect (OIDC) identity provider, IAM roles for service-account and trusted policy to support fine-grained IAM role based access to pod level using service accounts. This change is made to test the functionality and address #122 
 
# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No it is an optional addons. 