### PR TITLE
Flux cd install refactor

### DIFF
--- a/examples/stage/odc_k8s/odc_k8s.tf
+++ b/examples/stage/odc_k8s/odc_k8s.tf
@@ -35,18 +35,18 @@ module "odc_k8s" {
   db_admin_password = data.terraform_remote_state.odc_eks-stage.outputs.db_admin_username
 
   # Setup Flux/FluxCloud
+  flux_enabled = false
+  flux_git_repo_url = "https://github.com/opendatacube/flux-odc-sample"
+  flux_git_branch = "master"
+  flux_git_path = "flux"
+  #flux_git_label = "flux-sync"
+
   fluxcloud_enabled = false
-  fluxcloud_slack_url = "" # "https://hooks.slack.com/services/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"
+  fluxcloud_slack_url = "" # "https://hooks.slack.com/services/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"
   fluxcloud_slack_channel = "" # "#ga-wms-updates"
-  fluxcloud_slack_name = "Flux Deployer"
+  fluxcloud_slack_name = "Flux Example Deployer"
   fluxcloud_slack_emoji = ":zoidberg:"
   fluxcloud_github_url = "https://github.com/opendatacube/flux-odc-sample"
   fluxcloud_commit_template = "{{ .VCSLink }}/commits/{{ .Commit }}"
-
-  # Setup Flux CD
-  flux_enabled = false
-  #flux_git_repo_url = "<repo goes here>"
-  #flux_git_branch = "master"
-  #flux_git_label = "flux-sync"
 
 }

--- a/examples/stage/odc_k8s/odc_k8s.tf
+++ b/examples/stage/odc_k8s/odc_k8s.tf
@@ -36,13 +36,17 @@ module "odc_k8s" {
 
   # Setup Flux/FluxCloud
   fluxcloud_enabled = false
-//  flux_git_repo_url = ""
-//  flux_git_branch = ""
-//  flux_git_label = ""
   fluxcloud_slack_url = "" # "https://hooks.slack.com/services/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"
   fluxcloud_slack_channel = "" # "#ga-wms-updates"
   fluxcloud_slack_name = "Flux Deployer"
   fluxcloud_slack_emoji = ":zoidberg:"
   fluxcloud_github_url = "https://github.com/opendatacube/flux-odc-sample"
   fluxcloud_commit_template = "{{ .VCSLink }}/commits/{{ .Commit }}"
+
+  # Setup Flux CD
+  flux_enabled = false
+  #flux_git_repo_url = "<repo goes here>"
+  #flux_git_branch = "master"
+  #flux_git_label = "flux-sync"
+
 }

--- a/examples/stage/odc_k8s/odc_k8s.tf
+++ b/examples/stage/odc_k8s/odc_k8s.tf
@@ -36,7 +36,7 @@ module "odc_k8s" {
 
   # Setup Flux/FluxCloud
   flux_enabled = false
-  flux_git_repo_url = "https://github.com/opendatacube/flux-odc-sample"
+  flux_git_repo_url = "git@github.com:opendatacube/flux-odc-sample.git"
   flux_git_branch = "master"
   flux_git_path = "flux"
   #flux_git_label = "flux-sync"

--- a/examples/stage/odc_k8s/odc_k8s.tf
+++ b/examples/stage/odc_k8s/odc_k8s.tf
@@ -42,8 +42,8 @@ module "odc_k8s" {
   #flux_git_label = "flux-sync"
 
   fluxcloud_enabled = false
-  fluxcloud_slack_url = "" # "https://hooks.slack.com/services/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"
-  fluxcloud_slack_channel = "" # "#ga-wms-updates"
+  fluxcloud_slack_url = ""
+  fluxcloud_slack_channel = ""
   fluxcloud_slack_name = "Flux Example Deployer"
   fluxcloud_slack_emoji = ":zoidberg:"
   fluxcloud_github_url = "https://github.com/opendatacube/flux-odc-sample"

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -5,7 +5,7 @@ git:
   pollInterval: 1m
 registry:
   pollInterval: 1m
-additionalArgs:
-  - --connect=ws://fluxcloud
+#additionalArgs:
+#  - --connect=ws://fluxcloud
 image:
   repository: fluxcd/flux

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -71,7 +71,7 @@ resource "helm_release" "flux" {
   name       = "flux"
   repository = "https://fluxcd.github.io/flux"
   chart      = "flux"
-  namespace  = "flux"
+  namespace  = kubernetes_namespace.flux[0].metadata[0].name
 
   values = [
     file("${path.module}/config/flux.yaml"),
@@ -97,9 +97,6 @@ resource "helm_release" "flux" {
     value = var.flux_git_label
   }
 
-  depends_on = [
-    kubernetes_namespace.flux,
-  ]
 }
 
 data "http" "flux_helm_release_crd_yaml" {
@@ -112,7 +109,7 @@ resource "null_resource" "apply_flux_crd" {
 
   triggers = {
     cluster_updated                     = data.aws_eks_cluster.cluster.id
-    kubernetes_namespace_updated        = "${join(",",kubernetes_namespace.flux.*.id)}"
+    kubernetes_namespace_updated        = "${join(",",kubernetes_namespace.flux[0].metadata[0].name)}"
 
     # Special trigger: When using null_resource, you can use the triggers map both to signal when the provisioners
     # need to re-run (the usual purpose as above) and to retain values you can access via self during the destroy phase.

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -54,7 +54,7 @@ resource "kubernetes_secret" "flux" {
 
   metadata {
     name = "flux"
-    namespace = kubernetes_namespace.flux[0].metadata.name[0]
+    namespace = kubernetes_namespace.flux[0].metadata[0].name
   }
 
   data = {

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -96,7 +96,9 @@ resource "helm_release" "flux" {
     name  = "git.label"
     value = var.flux_git_label
   }
-
+  depends_on = [
+    null_resource.apply_flux_crd,
+  ]
 }
 
 data "http" "flux_helm_release_crd_yaml" {

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -107,7 +107,7 @@ resource "helm_release" "flux-helm-operator" {
 }
 
 data "http" "flux_helm_release_crd_yaml" {
-  url = "https://raw.githubusercontent.com/fluxcd/flux/helm-0.10.1/deploy-helm/flux-helm-release-crd.yaml"
+  url = "https://raw.githubusercontent.com/fluxcd/helm-operator/chart-0.3.0/deploy/flux-helm-release-crd.yaml"
 }
 
 

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -69,7 +69,8 @@ resource "kubernetes_secret" "flux" {
 resource "helm_release" "flux" {
   count      = var.flux_enabled ? 1 : 0
   name       = "flux"
-  repository = "https://fluxcd.github.io/flux"
+  #repository = "https://fluxcd.github.io/flux"
+  repository = "https://charts.fluxcd.io"
   chart      = "flux"
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 
@@ -104,11 +105,12 @@ resource "helm_release" "flux" {
     null_resource.apply_flux_crd,
   ]
 }
-
-resource "helm_release" "flux_operator" {
+# THIS APPEARS TO BE OUT OF DATE INFORMATION - TRY USING THE INSTRUCTIONS FROM THE HELM OPERATOR LINK ON FLUXcd.io
+resource "helm_release" "flux_helm_operator" {
   count      = var.flux_enabled ? 1 : 0
-  name       = "helm-operator"
-  repository = "https://fluxcd.github.io/flux"
+  name       = "flux-helm-operator"
+  #repository = "https://fluxcd.github.io/flux"
+  repository = "https://charts.fluxcd.io"
   chart      = "helm-operator"
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -109,7 +109,7 @@ resource "null_resource" "apply_flux_crd" {
 
   triggers = {
     cluster_updated                     = data.aws_eks_cluster.cluster.id
-    kubernetes_namespace_updated        = "${join(",",kubernetes_namespace.flux[0].metadata[0].name)}"
+    kubernetes_namespace_updated        = kubernetes_namespace.flux[0].metadata[0].name
 
     # Special trigger: When using null_resource, you can use the triggers map both to signal when the provisioners
     # need to re-run (the usual purpose as above) and to retain values you can access via self during the destroy phase.

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -53,13 +53,13 @@ resource "kubernetes_secret" "flux" {
   count = var.flux_enabled ? 1 : 0
 
   metadata {
-    name = "flux"
+    name = "flux-git-auth"
     namespace = kubernetes_namespace.flux[0].metadata[0].name
   }
 
   data = {
-    git_authuser = var.fluxcd_git_authuser
-    git_authkey = var.fluxcd_git_authkey
+    GIT_AUTHUSER = var.fluxcd_git_authuser
+    GIT_AUTHKEY = var.fluxcd_git_authkey
   }
 
   type = "Opaque"
@@ -95,6 +95,10 @@ resource "helm_release" "flux" {
   set {
     name  = "git.label"
     value = var.flux_git_label
+  }
+  set {
+    name = "secretName"
+    value = kubernetes_secret.flux[0].metadata[0].name
   }
   depends_on = [
     null_resource.apply_flux_crd,

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -75,10 +75,6 @@ resource "helm_release" "flux" {
   version    = "1.0.0"
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 
-  values = [
-    file("${path.module}/config/flux.yaml"),
-  ]
-
   set {
     name  = "git.url"
     value = var.flux_git_repo_url
@@ -98,18 +94,33 @@ resource "helm_release" "flux" {
     name  = "git.label"
     value = var.flux_git_label
   }
+
+  set {
+    name  = "helmOperator.create"
+    value = true
+  }
+  set {
+    name  = "helmOperator.createCRD"
+    value = false
+  }
+  set {
+    name  = "git.pollInterval"
+    value = "1m"
+  }
+  set {
+    name  = "registry.pollInterval"
+    value = "1m"
+  }
+  # TODO: These should be optional and the syntax for additional args is probably wrong
+  # set {
+  #   name  = "additionalArgs"
+  #   value = "- --connect=ws://fluxcloud"
+  # }
   # set {
   #   name = "secretName"
   #   value = kubernetes_secret.flux[0].metadata[0].name
   # }
-  # set {
-  #   name = "helmOperator.create"
-  #   value = "true"
-  # }
-  # set {
-  #   name = "helmOperator.createCRD"
-  #   value = "false"
-  # }
+  
   depends_on = [
     null_resource.apply_flux_crd,
   ]

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -72,7 +72,7 @@ resource "helm_release" "flux" {
   #repository = "https://fluxcd.github.io/flux"
   repository = "https://charts.fluxcd.io"
   chart      = "fluxcd/flux"
-  version    = "1.17.0"
+  version    = "1.0.0"
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 
   values = [

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -71,7 +71,8 @@ resource "helm_release" "flux" {
   name       = "flux"
   #repository = "https://fluxcd.github.io/flux"
   repository = "https://charts.fluxcd.io"
-  chart      = "flux"
+  chart      = "fluxcd/flux"
+  version    = "1.17.0"
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 
   values = [
@@ -97,26 +98,20 @@ resource "helm_release" "flux" {
     name  = "git.label"
     value = var.flux_git_label
   }
+  # set {
+  #   name = "secretName"
+  #   value = kubernetes_secret.flux[0].metadata[0].name
+  # }
   set {
-    name = "secretName"
-    value = kubernetes_secret.flux[0].metadata[0].name
+    name = "helmOperator.create"
+    value = "true"
+  }
+  set {
+    name = "helmOperator.createCRD"
+    value = "false"
   }
   depends_on = [
     null_resource.apply_flux_crd,
-  ]
-}
-# THIS APPEARS TO BE OUT OF DATE INFORMATION - TRY USING THE INSTRUCTIONS FROM THE HELM OPERATOR LINK ON FLUXcd.io
-resource "helm_release" "flux_helm_operator" {
-  count      = var.flux_enabled ? 1 : 0
-  name       = "flux-helm-operator"
-  #repository = "https://fluxcd.github.io/flux"
-  repository = "https://charts.fluxcd.io"
-  chart      = "helm-operator"
-  namespace  = kubernetes_namespace.flux[0].metadata[0].name
-
-  depends_on = [
-    null_resource.apply_flux_crd,
-    helm_release.flux,
   ]
 }
 

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -102,14 +102,14 @@ resource "helm_release" "flux" {
   #   name = "secretName"
   #   value = kubernetes_secret.flux[0].metadata[0].name
   # }
-  set {
-    name = "helmOperator.create"
-    value = "true"
-  }
-  set {
-    name = "helmOperator.createCRD"
-    value = "false"
-  }
+  # set {
+  #   name = "helmOperator.create"
+  #   value = "true"
+  # }
+  # set {
+  #   name = "helmOperator.createCRD"
+  #   value = "false"
+  # }
   depends_on = [
     null_resource.apply_flux_crd,
   ]

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -105,6 +105,19 @@ resource "helm_release" "flux" {
   ]
 }
 
+resource "helm_release" "flux_operator" {
+  count      = var.flux_enabled ? 1 : 0
+  name       = "helm-operator"
+  repository = "https://fluxcd.github.io/flux"
+  chart      = "helm-operator"
+  namespace  = kubernetes_namespace.flux[0].metadata[0].name
+
+  depends_on = [
+    null_resource.apply_flux_crd,
+    helm_release.flux,
+  ]
+}
+
 data "http" "flux_helm_release_crd_yaml" {
   url = "https://raw.githubusercontent.com/fluxcd/flux/helm-0.10.1/deploy-helm/flux-helm-release-crd.yaml"
 }

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -29,6 +29,14 @@ variable "flux_git_label" {
   default     = "flux-sync"
 }
 
+variable "fluxcd_git_authuser" {
+  type        = string
+}
+
+variable "fluxcd_git_authkey" {
+  type        = string
+}
+
 resource "kubernetes_namespace" "flux" {
   count = var.flux_enabled ? 1 : 0
 
@@ -40,6 +48,23 @@ resource "kubernetes_namespace" "flux" {
     }
   }
 }
+
+resource "kubernetes_secret" "flux" {
+  count = var.flux_enabled ? 1 : 0
+
+  metadata {
+    name = "flux"
+    namespace = kubernetes_namespace.flux[count.index].metadata.name[0]
+  }
+
+  data = {
+    git_authuser = var.fluxcd_git_authuser
+    git_authkey = var.fluxcd_git_authkey
+  }
+
+  type = "Opaque"
+}
+
 
 resource "helm_release" "flux" {
   count      = var.flux_enabled ? 1 : 0

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -54,7 +54,7 @@ resource "kubernetes_secret" "flux" {
 
   metadata {
     name = "flux"
-    namespace = kubernetes_namespace.flux[count.index].metadata.name[0]
+    namespace = kubernetes_namespace.flux[0].metadata.name[0]
   }
 
   data = {

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -71,7 +71,7 @@ resource "helm_release" "flux" {
   name       = "flux"
   #repository = "https://fluxcd.github.io/flux"
   repository = "https://charts.fluxcd.io"
-  chart      = "fluxcd/flux"
+  chart      = "flux"
   version    = "1.0.0"
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 

--- a/odc_k8s/install_extra_software.tf
+++ b/odc_k8s/install_extra_software.tf
@@ -63,7 +63,7 @@ locals {
 set -e
 install_aws_cli=${var.install_aws_cli}
 if [[ "$install_aws_cli" = true ]] ; then
-  export PATH=$PATH:${local.external_packages_install_path}:${local.external_packages_install_path}/bin
+  export PATH=${local.external_packages_install_path}:${local.external_packages_install_path}/bin:$PATH
   if [ ! -f ${local.external_packages_install_path}/aws_cli_installed ] ; then
       echo 'Installing AWS CLI...'
       mkdir -p ${local.external_packages_install_path}
@@ -79,7 +79,7 @@ if [[ "$install_aws_cli" = true ]] ; then
 fi
 install_kubectl=${var.install_kubectl}
 if [[ "$install_kubectl" = true ]] ; then
-  export PATH=$PATH:${local.external_packages_install_path}
+  export PATH=${local.external_packages_install_path}:$PATH
   if [ ! -f ${local.external_packages_install_path}/kubectl_installed ] ; then
       echo 'Installing kubectl...'
       mkdir -p ${local.external_packages_install_path}


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Update to flux/helm-operator current stable release (flux 1.17.0)

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

If there is an existing fluxcd deployment this will replace it and possibly not upgrade in place. It may well change the ssh public key in use to auth to the git repo so that will need updating in the repo as well. Unfortunately I've been unable to find any "upgrading" instructions and I don't have an old version to test against.

I suggest first turn off the flux deployment in terraform to remove it and then turn it on with the update in place might be a good start.