### PR TITLE
Test flux release robw

### DIFF
--- a/odc_eks/outputs.tf
+++ b/odc_eks/outputs.tf
@@ -19,6 +19,14 @@ output "owner"  {
   value = var.owner
 }
 
+output "namespace"  {
+  value = var.namespace
+}
+
+output "environment"  {
+  value = var.environment
+}
+
 output "db_hostname" {
   value = module.db.db_hostname
 }


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add
Additional outputs for use by other terraform components.
In this particular case its useful in the [flux-odc-sample/odc_k8s_core.tf](https://github.com/opendatacube/flux-odc-sample/blob/test-flux-release/tf/examples/stage/odc_k8s_core.tf) so the region,owner,namespace,and environment vars can be set from the remote state for the eks/k8s cluster.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here
