### PR TITLE
asg update - ASG per availability zone

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -35,16 +35,16 @@ This page gives an overview of all possible variables that can be put in a `terr
 | [default_worker_instance_type](#default_worker_instance_type)                               | Nodes                | No  | "" |
 | [group_enabled](#group_enabled)                                                             | Nodes                | No  | false |
 | [spot_nodes_enabled](#spot_nodes_enabled)                                                   | Nodes                | No  | false |
-| [min_nodes](#min_nodes)                                                                     | Nodes                | No  | 0 |
-| [desired_nodes](#desired_nodes)                                                             | Nodes                | No  | 0 |
-| [max_nodes](#max_nodes)                                                                     | Nodes                | No  | 0 |
-| [min_spot_nodes](#min_spot_nodes)                                                           | Nodes                | No  | 0 |
-| [max_spot_nodes](#max_spot_nodes)                                                           | Nodes                | No  | 0 |
-| [min_nodes_per_az](#min_nodes_per_az)                                                       | Nodes                | No  | 1 |
-| [desired_nodes_per_az](#desired_nodes_per_az)                                               | Nodes                | No  | 1 |
-| [max_nodes_per_az](#max_nodes_per_az)                                                       | Nodes                | No  | 2 |
+| [min_nodes](#min_nodes)                                                                     | Nodes                | No  | { ap-southeast-2a: 0, ap-southeast-2b: 0, ap-southeast-2c: 0 } |
+| [desired_nodes](#desired_nodes)                                                             | Nodes                | No  | { ap-southeast-2a: 0, ap-southeast-2b: 0, ap-southeast-2c: 0 } |
+| [max_nodes](#max_nodes)                                                                     | Nodes                | No  | { ap-southeast-2a: 0, ap-southeast-2b: 0, ap-southeast-2c: 0 } |
+| [min_spot_nodes](#min_spot_nodes)                                                           | Nodes                | No  | { ap-southeast-2a: 0, ap-southeast-2b: 0, ap-southeast-2c: 0 } |
+| [max_spot_nodes](#max_spot_nodes)                                                           | Nodes                | No  | { ap-southeast-2a: 0, ap-southeast-2b: 0, ap-southeast-2c: 0 } |
+| [min_nodes_per_az](#min_nodes_per_az)                                                       | Nodes                | No  | 0 |
+| [desired_nodes_per_az](#desired_nodes_per_az)                                               | Nodes                | No  | 0 |
+| [max_nodes_per_az](#max_nodes_per_az)                                                       | Nodes                | No  | 0 |
 | [min_spot_nodes_per_az](#min_spot_nodes_per_az)                                             | Nodes                | No  | 0 |
-| [max_spot_nodes_per_az](#max_spot_nodes_per_az)                                             | Nodes                | No  | 2 |
+| [max_spot_nodes_per_az](#max_spot_nodes_per_az)                                             | Nodes                | No  | 0 |
 | [max_spot_price](#max_spot_price)                                                           | Nodes                | No  | "0.40" |
 | [volume_size](#volume_size)                                                                 | Nodes                | No  | 20 |
 | [spot_volume_size](#spot_volume_size)                                                       | Nodes                | No  | 20 |

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -54,11 +54,11 @@ locals {
   node_security_group   = element(data.aws_security_groups.nodes.ids, 0)
   # use node var or generate it from subnet count * nodes_per_az for legacy support
   # to set it to 0 both the nodes var and nodes_per_az must be 0
-  min_nodes = var.min_nodes > 0 ? var.min_nodes : var.min_nodes_per_az * length(data.aws_subnet_ids.nodes.ids)
-  max_nodes = var.max_nodes > 0 ? var.max_nodes : var.max_nodes_per_az * length(data.aws_subnet_ids.nodes.ids)
-  desired_nodes = var.desired_nodes > 0 ? var.desired_nodes : var.desired_nodes_per_az * length(data.aws_subnet_ids.nodes.ids)
-  min_spot_nodes = var.min_spot_nodes > 0 ? var.min_spot_nodes : var.min_spot_nodes_per_az * length(data.aws_subnet_ids.nodes.ids)
-  max_spot_nodes = var.max_spot_nodes > 0 ? var.max_spot_nodes : var.max_spot_nodes_per_az * length(data.aws_subnet_ids.nodes.ids)
+  min_nodes = (var.min_nodes_per_az > 0) ? { az0: var.min_nodes_per_az, az1 = var.min_nodes_per_az, az2 = var.min_nodes_per_az } : var.min_nodes
+  max_nodes = (var.max_nodes_per_az > 0) ? { az0: var.max_nodes_per_az, az1 = var.max_nodes_per_az, az2 = var.max_nodes_per_az } : var.max_nodes
+  desired_nodes = (var.desired_nodes_per_az > 0) ? { az0: var.desired_nodes_per_az, az1 = var.desired_nodes_per_az, az2 = var.desired_nodes_per_az } : var.desired_nodes
+  min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { az0: var.min_spot_nodes_per_az, az1 = var.min_spot_nodes_per_az, az2 = var.min_spot_nodes_per_az } : var.min_spot_nodes
+  max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { az0: var.max_spot_nodes_per_az, az1 = var.max_spot_nodes_per_az, az2 = var.max_spot_nodes_per_az } : var.max_spot_nodes
 }
 
 module "workers" {

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -53,12 +53,12 @@ locals {
   certificate_authority = element(data.aws_eks_cluster.eks.*.certificate_authority.0.data, 0)
   node_security_group   = element(data.aws_security_groups.nodes.ids, 0)
   # use node var or generate it from subnet count * nodes_per_az for legacy support
-  # to set it to 0 both the nodes var and nodes_per_az must be 0
-  # min_nodes = (var.min_nodes_per_az > 0) ? { az0: var.min_nodes_per_az, az1 = var.min_nodes_per_az, az2 = var.min_nodes_per_az } : var.min_nodes
-  # max_nodes = (var.max_nodes_per_az > 0) ? { az0: var.max_nodes_per_az, az1 = var.max_nodes_per_az, az2 = var.max_nodes_per_az } : var.max_nodes
-  # desired_nodes = (var.desired_nodes_per_az > 0) ? { az0: var.desired_nodes_per_az, az1 = var.desired_nodes_per_az, az2 = var.desired_nodes_per_az } : var.desired_nodes
-  # min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { az0: var.min_spot_nodes_per_az, az1 = var.min_spot_nodes_per_az, az2 = var.min_spot_nodes_per_az } : var.min_spot_nodes
-  # max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { az0: var.max_spot_nodes_per_az, az1 = var.max_spot_nodes_per_az, az2 = var.max_spot_nodes_per_az } : var.max_spot_nodes
+  # The default values are set to 0 for both the _nodes and _nodes_per_az
+  min_nodes = (var.min_nodes_per_az > 0) ? { az_0: var.min_nodes_per_az, az_1 = var.min_nodes_per_az, az_2 = var.min_nodes_per_az } : var.min_nodes
+  max_nodes = (var.max_nodes_per_az > 0) ? { az_0: var.max_nodes_per_az, az_1 = var.max_nodes_per_az, az_2 = var.max_nodes_per_az } : var.max_nodes
+  desired_nodes = (var.desired_nodes_per_az > 0) ? { az_0: var.desired_nodes_per_az, az_1 = var.desired_nodes_per_az, az_2 = var.desired_nodes_per_az } : var.desired_nodes
+  min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { az_0: var.min_spot_nodes_per_az, az_1 = var.min_spot_nodes_per_az, az_2 = var.min_spot_nodes_per_az } : var.min_spot_nodes
+  max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { az_0: var.max_spot_nodes_per_az, az_1 = var.max_spot_nodes_per_az, az_2 = var.max_spot_nodes_per_az } : var.max_spot_nodes
 }
 
 module "workers" {
@@ -72,11 +72,11 @@ module "workers" {
   nodes_subnet_group           = data.aws_subnet_ids.nodes.ids
   node_security_group          = local.node_security_group
   node_instance_profile        = "${var.cluster_name}-node"
-  min_nodes                    = var.min_nodes
-  max_nodes                    = var.max_nodes
-  desired_nodes                = var.desired_nodes
-  min_spot_nodes               = var.min_spot_nodes
-  max_spot_nodes               = var.max_spot_nodes
+  min_nodes                    = local.min_nodes
+  max_nodes                    = local.max_nodes
+  desired_nodes                = local.desired_nodes
+  min_spot_nodes               = local.min_spot_nodes
+  max_spot_nodes               = local.max_spot_nodes
   node_group_name              = var.node_group_name
   ami_image_id                 = var.ami_image_id
   default_worker_instance_type = var.default_worker_instance_type

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -54,11 +54,11 @@ locals {
   node_security_group   = element(data.aws_security_groups.nodes.ids, 0)
   # use node var or generate it from subnet count * nodes_per_az for legacy support
   # The default values are set to 0 for both the _nodes and _nodes_per_az
-  min_nodes = (var.min_nodes_per_az > 0) ? { az_0: var.min_nodes_per_az, az_1 = var.min_nodes_per_az, az_2 = var.min_nodes_per_az } : var.min_nodes
-  max_nodes = (var.max_nodes_per_az > 0) ? { az_0: var.max_nodes_per_az, az_1 = var.max_nodes_per_az, az_2 = var.max_nodes_per_az } : var.max_nodes
-  desired_nodes = (var.desired_nodes_per_az > 0) ? { az_0: var.desired_nodes_per_az, az_1 = var.desired_nodes_per_az, az_2 = var.desired_nodes_per_az } : var.desired_nodes
-  min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { az_0: var.min_spot_nodes_per_az, az_1 = var.min_spot_nodes_per_az, az_2 = var.min_spot_nodes_per_az } : var.min_spot_nodes
-  max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { az_0: var.max_spot_nodes_per_az, az_1 = var.max_spot_nodes_per_az, az_2 = var.max_spot_nodes_per_az } : var.max_spot_nodes
+  min_nodes = (var.min_nodes_per_az > 0) ? { ap-southeast-2a: var.min_nodes_per_az, ap-southeast-2b: var.min_nodes_per_az, ap-southeast-2c: var.min_nodes_per_az } : var.min_nodes
+  max_nodes = (var.max_nodes_per_az > 0) ? { ap-southeast-2a: var.max_nodes_per_az, ap-southeast-2b: var.max_nodes_per_az, ap-southeast-2c: var.max_nodes_per_az } : var.max_nodes
+  desired_nodes = (var.desired_nodes_per_az > 0) ? { ap-southeast-2a: var.desired_nodes_per_az, ap-southeast-2b: var.desired_nodes_per_az, ap-southeast-2c: var.desired_nodes_per_az } : var.desired_nodes
+  min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { ap-southeast-2a: var.min_spot_nodes_per_az, ap-southeast-2b: var.min_spot_nodes_per_az, ap-southeast-2c: var.min_spot_nodes_per_az } : var.min_spot_nodes
+  max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { ap-southeast-2a: var.max_spot_nodes_per_az, ap-southeast-2b: var.max_spot_nodes_per_az, ap-southeast-2c: var.max_spot_nodes_per_az } : var.max_spot_nodes
 }
 
 module "workers" {

--- a/nodes/main.tf
+++ b/nodes/main.tf
@@ -54,11 +54,11 @@ locals {
   node_security_group   = element(data.aws_security_groups.nodes.ids, 0)
   # use node var or generate it from subnet count * nodes_per_az for legacy support
   # to set it to 0 both the nodes var and nodes_per_az must be 0
-  min_nodes = (var.min_nodes_per_az > 0) ? { az0: var.min_nodes_per_az, az1 = var.min_nodes_per_az, az2 = var.min_nodes_per_az } : var.min_nodes
-  max_nodes = (var.max_nodes_per_az > 0) ? { az0: var.max_nodes_per_az, az1 = var.max_nodes_per_az, az2 = var.max_nodes_per_az } : var.max_nodes
-  desired_nodes = (var.desired_nodes_per_az > 0) ? { az0: var.desired_nodes_per_az, az1 = var.desired_nodes_per_az, az2 = var.desired_nodes_per_az } : var.desired_nodes
-  min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { az0: var.min_spot_nodes_per_az, az1 = var.min_spot_nodes_per_az, az2 = var.min_spot_nodes_per_az } : var.min_spot_nodes
-  max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { az0: var.max_spot_nodes_per_az, az1 = var.max_spot_nodes_per_az, az2 = var.max_spot_nodes_per_az } : var.max_spot_nodes
+  # min_nodes = (var.min_nodes_per_az > 0) ? { az0: var.min_nodes_per_az, az1 = var.min_nodes_per_az, az2 = var.min_nodes_per_az } : var.min_nodes
+  # max_nodes = (var.max_nodes_per_az > 0) ? { az0: var.max_nodes_per_az, az1 = var.max_nodes_per_az, az2 = var.max_nodes_per_az } : var.max_nodes
+  # desired_nodes = (var.desired_nodes_per_az > 0) ? { az0: var.desired_nodes_per_az, az1 = var.desired_nodes_per_az, az2 = var.desired_nodes_per_az } : var.desired_nodes
+  # min_spot_nodes = (var.min_spot_nodes_per_az > 0) ? { az0: var.min_spot_nodes_per_az, az1 = var.min_spot_nodes_per_az, az2 = var.min_spot_nodes_per_az } : var.min_spot_nodes
+  # max_spot_nodes = (var.max_spot_nodes_per_az > 0) ? { az0: var.max_spot_nodes_per_az, az1 = var.max_spot_nodes_per_az, az2 = var.max_spot_nodes_per_az } : var.max_spot_nodes
 }
 
 module "workers" {
@@ -72,11 +72,11 @@ module "workers" {
   nodes_subnet_group           = data.aws_subnet_ids.nodes.ids
   node_security_group          = local.node_security_group
   node_instance_profile        = "${var.cluster_name}-node"
-  min_nodes                    = local.min_nodes
-  max_nodes                    = local.max_nodes
-  desired_nodes                = local.desired_nodes
-  min_spot_nodes               = local.min_spot_nodes
-  max_spot_nodes               = local.max_spot_nodes
+  min_nodes                    = var.min_nodes
+  max_nodes                    = var.max_nodes
+  desired_nodes                = var.desired_nodes
+  min_spot_nodes               = var.min_spot_nodes
+  max_spot_nodes               = var.max_spot_nodes
   node_group_name              = var.node_group_name
   ami_image_id                 = var.ami_image_id
   default_worker_instance_type = var.default_worker_instance_type

--- a/nodes/modules/workers/variables.tf
+++ b/nodes/modules/workers/variables.tf
@@ -43,41 +43,41 @@ variable "nodes_enabled" {
 
 variable "min_nodes" {
   default = {
-    az1 = 0
-    az2 = 0
-    az3 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "desired_nodes" {
   default = {
-    az1 = 0
-    az2 = 0
-    az3 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "max_nodes" {
   default = {
-    az0 = 0
-    az1 = 0
-    az2 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "min_spot_nodes" {
   default = {
-    az0 = 0
-    az1 = 0
-    az2 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "max_spot_nodes" {
   default = {
-    az0 = 0
-    az1 = 0
-    az2 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 

--- a/nodes/modules/workers/variables.tf
+++ b/nodes/modules/workers/variables.tf
@@ -42,23 +42,43 @@ variable "nodes_enabled" {
 }
 
 variable "min_nodes" {
-  default = 1
+  default = {
+    az1 = 0
+    az2 = 0
+    az3 = 0
+  }
 }
 
 variable "desired_nodes" {
-  default = 1
+  default = {
+    az1 = 0
+    az2 = 0
+    az3 = 0
+  }
 }
 
 variable "max_nodes" {
-  default = 2
+  default = {
+    az0 = 0
+    az1 = 0
+    az2 = 0
+  }
 }
 
 variable "min_spot_nodes" {
-  default = 0
+  default = {
+    az0 = 0
+    az1 = 0
+    az2 = 0
+  }
 }
 
 variable "max_spot_nodes" {
-  default = 2
+  default = {
+    az0 = 0
+    az1 = 0
+    az2 = 0
+  }
 }
 
 variable "volume_size" {

--- a/nodes/modules/workers/variables.tf
+++ b/nodes/modules/workers/variables.tf
@@ -43,25 +43,25 @@ variable "nodes_enabled" {
 
 variable "min_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 
 variable "desired_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 
 variable "max_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 

--- a/nodes/modules/workers/variables.tf
+++ b/nodes/modules/workers/variables.tf
@@ -67,17 +67,17 @@ variable "max_nodes" {
 
 variable "min_spot_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 
 variable "max_spot_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -46,7 +46,7 @@ USERDATA
 }
 
 resource "aws_launch_template" "node" {
-  count = (var.nodes_enabled ? 1 : 0) * length(var.nodes_subnet_group)
+  count = var.nodes_enabled ? length(var.nodes_subnet_group) : 0
   name_prefix = var.cluster_name
   image_id = local.ami_id
   user_data = base64encode(local.eks-node-userdata)

--- a/nodes/modules/workers/worker_image.tf
+++ b/nodes/modules/workers/worker_image.tf
@@ -46,7 +46,7 @@ USERDATA
 }
 
 resource "aws_launch_template" "node" {
-  count = var.nodes_enabled ? 1 : 0
+  count = (var.nodes_enabled ? 1 : 0) * length(var.nodes_subnet_group)
   name_prefix = var.cluster_name
   image_id = local.ami_id
   user_data = base64encode(local.eks-node-userdata)
@@ -57,6 +57,7 @@ resource "aws_launch_template" "node" {
   }
 
   network_interfaces {
+    subnet_id = var.nodes_subnet_group[count.index]
     associate_public_ip_address = false
     security_groups = [var.node_security_group]
     delete_on_termination = true
@@ -76,7 +77,7 @@ resource "aws_launch_template" "node" {
 }
 
 resource "aws_launch_template" "spot" {
-  count = var.spot_nodes_enabled ? 1 : 0
+  count = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
   name_prefix = var.cluster_name
   image_id = local.ami_id
   user_data = base64encode(local.eks-spot-userdata)
@@ -91,6 +92,7 @@ resource "aws_launch_template" "spot" {
   }
 
   network_interfaces {
+    subnet_id = var.nodes_subnet_group[count.index]
     associate_public_ip_address = false
     security_groups = [var.node_security_group]
     delete_on_termination = true

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -8,7 +8,7 @@ resource "aws_autoscaling_group" "nodes" {
   desired_capacity = lookup(var.desired_nodes, data.aws_subnet.nodes_subnet[count.index].availability_zone)
   max_size         = lookup(var.max_nodes, data.aws_subnet.nodes_subnet[count.index].availability_zone)
   min_size         = lookup(var.min_nodes, data.aws_subnet.nodes_subnet[count.index].availability_zone)
-  name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
+  name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-nodes-${count.index}"
   vpc_zone_identifier = [data.aws_subnet.nodes_subnet[count.index].id]
 
   # Don't reset to default size every time terraform is applied

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -50,9 +50,6 @@ resource "aws_autoscaling_group" "nodes" {
     },
   ]
 
-  # Don't break cluster autoscaler
-  suspended_processes = ["AZRebalance"]
-
   depends_on = [aws_launch_template.node]
 }
 
@@ -107,9 +104,6 @@ resource "aws_autoscaling_group" "spot_nodes" {
       propagate_at_launch = true
     },
   ]
-
-  # Don't break cluster autoscaler
-  suspended_processes = ["AZRebalance"]
   
   depends_on = [aws_launch_template.spot]
 }

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,10 +1,10 @@
 resource "aws_autoscaling_group" "nodes" {
-  count            = var.nodes_enabled ? 1 : 0
+  count            = var.nodes_enabled ? length(var.nodes_subnet_group) : 0
   desired_capacity = var.desired_nodes
   max_size         = var.max_nodes
   min_size         = var.min_nodes
-  name             = "${var.node_group_name}-${aws_launch_template.node[0].id}-nodes-0"
-  vpc_zone_identifier = var.nodes_subnet_group
+  name             = "${var.node_group_name}-${aws_launch_template.node[count.index].id}-nodes-${count.index}"
+  vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied
   lifecycle {
@@ -13,14 +13,14 @@ resource "aws_autoscaling_group" "nodes" {
   }
 
   launch_template {
-    id      = aws_launch_template.node[0].id
-    version = aws_launch_template.node[0].latest_version
+    id      = element(aws_launch_template.node.*.id, count.index)
+    version = element(aws_launch_template.node.*.latest_version, count.index)
   }
 
   tags = [
     {
       key                 = "Name"
-      value               = "${var.cluster_name}-node"
+      value               = "${var.cluster_name}-node-${count.index}"
       propagate_at_launch = true
     },
     {
@@ -57,12 +57,12 @@ resource "aws_autoscaling_group" "nodes" {
 }
 
 resource "aws_autoscaling_group" "spot_nodes" {
-  count            = var.spot_nodes_enabled ? 1 : 0
+  count            = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
   desired_capacity = var.desired_nodes
   max_size         = var.max_spot_nodes
   min_size         = var.min_spot_nodes
-  name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot-0"
-  vpc_zone_identifier = var.nodes_subnet_group
+  name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
+  vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied
   lifecycle {
@@ -71,14 +71,14 @@ resource "aws_autoscaling_group" "spot_nodes" {
   }
 
   launch_template {
-    id      = aws_launch_template.spot[0].id
-    version = aws_launch_template.spot[0].latest_version
+    id      = element(aws_launch_template.spot.*.id, count.index)
+    version = element(aws_launch_template.spot.*.latest_version, count.index)
   }
 
   tags = [
     {
       key                 = "Name"
-      value               = "${var.cluster_name}-spot"
+      value               = "${var.cluster_name}-spot-${count.index}"
       propagate_at_launch = true
     },
     {

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,5 +1,5 @@
 resource "aws_autoscaling_group" "nodes" {
-  count            = var.nodes_enabled ? 3 : 0
+  count            = var.nodes_enabled ? length(var.nodes_subnet_group) : 0
   desired_capacity = lookup(var.desired_nodes, "az_${count.index}")
   max_size         = lookup(var.max_nodes, "az_${count.index}")
   min_size         = lookup(var.min_nodes, "az_${count.index}")

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,8 +1,8 @@
 resource "aws_autoscaling_group" "nodes" {
-  count            = var.nodes_enabled ? length(var.nodes_subnet_group) : 0
-  desired_capacity = var.desired_nodes
-  max_size         = var.max_nodes
-  min_size         = var.min_nodes
+  count            = var.nodes_enabled ? length(var.max_nodes) : 0
+  desired_capacity = "${lookup(var.desired_nodes, concat("az", count.index))}"
+  max_size         = "${lookup(var.max_nodes, concat("az", count.index))}"
+  min_size         = "${lookup(var.min_nodes, concat("az", count.index))}"
   name             = "${var.node_group_name}-${aws_launch_template.node[count.index].id}-nodes-${count.index}"
   vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
@@ -58,9 +58,9 @@ resource "aws_autoscaling_group" "nodes" {
 
 resource "aws_autoscaling_group" "spot_nodes" {
   count            = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
-  desired_capacity = var.desired_nodes
-  max_size         = var.max_spot_nodes
-  min_size         = var.min_spot_nodes
+  desired_capacity = "${lookup(var.min_spot_nodes, concat("az", count.index))}"
+  max_size         = "${lookup(var.max_spot_nodes, concat("az", count.index))}"
+  min_size         = "${lookup(var.min_spot_nodes, concat("az", count.index))}"
   name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
   vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -53,13 +53,19 @@ resource "aws_autoscaling_group" "nodes" {
   depends_on = [aws_launch_template.node]
 }
 
+# Declare the data source
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_autoscaling_group" "spot_nodes" {
   count            = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
-  desired_capacity = lookup(var.min_spot_nodes, "az_${count.index}")
-  max_size         = lookup(var.max_spot_nodes, "az_${count.index}")
-  min_size         = lookup(var.min_spot_nodes, "az_${count.index}")
+  availability_zones = [data.aws_availability_zones.available.names[count.index]]
+  desired_capacity = lookup(var.min_spot_nodes, "${data.aws_availability_zones.available.names[count.index]}")
+  max_size         = lookup(var.max_spot_nodes, "${data.aws_availability_zones.available.names[count.index]}")
+  min_size         = lookup(var.min_spot_nodes, "${data.aws_availability_zones.available.names[count.index]}")
   name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
-  vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
+//  vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied
   lifecycle {

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,9 +1,9 @@
 resource "aws_autoscaling_group" "nodes" {
-  count            = var.nodes_enabled ? length(var.max_nodes) : 0
+  count            = var.nodes_enabled ? 3 : 0
   desired_capacity = lookup(var.desired_nodes, "az_${count.index}")
   max_size         = lookup(var.max_nodes, "az_${count.index}")
   min_size         = lookup(var.min_nodes, "az_${count.index}")
-  name             = "${var.node_group_name}-${aws_launch_template.node[0].id}-nodes-${count.index}"
+  name             = "${var.node_group_name}-${aws_launch_template.node[count.index].id}-nodes-${count.index}"
   vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied
@@ -61,7 +61,7 @@ resource "aws_autoscaling_group" "spot_nodes" {
   desired_capacity = lookup(var.min_spot_nodes, "az_${count.index}")
   max_size         = lookup(var.max_spot_nodes, "az_${count.index}")
   min_size         = lookup(var.min_spot_nodes, "az_${count.index}")
-  name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot-${count.index}"
+  name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
   vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied

--- a/nodes/modules/workers/workers.tf
+++ b/nodes/modules/workers/workers.tf
@@ -1,9 +1,9 @@
 resource "aws_autoscaling_group" "nodes" {
   count            = var.nodes_enabled ? length(var.max_nodes) : 0
-  desired_capacity = "${lookup(var.desired_nodes, concat("az", count.index))}"
-  max_size         = "${lookup(var.max_nodes, concat("az", count.index))}"
-  min_size         = "${lookup(var.min_nodes, concat("az", count.index))}"
-  name             = "${var.node_group_name}-${aws_launch_template.node[count.index].id}-nodes-${count.index}"
+  desired_capacity = lookup(var.desired_nodes, "az_${count.index}")
+  max_size         = lookup(var.max_nodes, "az_${count.index}")
+  min_size         = lookup(var.min_nodes, "az_${count.index}")
+  name             = "${var.node_group_name}-${aws_launch_template.node[0].id}-nodes-${count.index}"
   vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied
@@ -58,10 +58,10 @@ resource "aws_autoscaling_group" "nodes" {
 
 resource "aws_autoscaling_group" "spot_nodes" {
   count            = var.spot_nodes_enabled ? length(var.nodes_subnet_group) : 0
-  desired_capacity = "${lookup(var.min_spot_nodes, concat("az", count.index))}"
-  max_size         = "${lookup(var.max_spot_nodes, concat("az", count.index))}"
-  min_size         = "${lookup(var.min_spot_nodes, concat("az", count.index))}"
-  name             = "${var.node_group_name}-${aws_launch_template.spot[count.index].id}-spot-${count.index}"
+  desired_capacity = lookup(var.min_spot_nodes, "az_${count.index}")
+  max_size         = lookup(var.max_spot_nodes, "az_${count.index}")
+  min_size         = lookup(var.min_spot_nodes, "az_${count.index}")
+  name             = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot-${count.index}"
   vpc_zone_identifier = [element(var.nodes_subnet_group, count.index)]
 
   # Don't reset to default size every time terraform is applied

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -19,43 +19,44 @@ variable "group_enabled" {
 variable "spot_nodes_enabled" {
   default = false
 }
+
 variable "min_nodes" {
   default = {
-    az1 = 0
-    az2 = 0
-    az3 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "desired_nodes" {
   default = {
-    az1 = 0
-    az2 = 0
-    az3 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "max_nodes" {
   default = {
-    az0 = 0
-    az1 = 0
-    az2 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "min_spot_nodes" {
   default = {
-    az0 = 0
-    az1 = 0
-    az2 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 
 variable "max_spot_nodes" {
   default = {
-    az0 = 0
-    az1 = 0
-    az2 = 0
+    az_0 = 0
+    az_1 = 0
+    az_2 = 0
   }
 }
 

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -46,17 +46,17 @@ variable "max_nodes" {
 
 variable "min_spot_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 
 variable "max_spot_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -20,23 +20,43 @@ variable "spot_nodes_enabled" {
   default = false
 }
 variable "min_nodes" {
-  default = 0
+  default = {
+    az1 = 0
+    az2 = 0
+    az3 = 0
+  }
 }
 
 variable "desired_nodes" {
-  default = 0
+  default = {
+    az1 = 0
+    az2 = 0
+    az3 = 0
+  }
 }
 
 variable "max_nodes" {
-  default = 0
+  default = {
+    az0 = 0
+    az1 = 0
+    az2 = 0
+  }
 }
 
 variable "min_spot_nodes" {
-  default = 0
+  default = {
+    az0 = 0
+    az1 = 0
+    az2 = 0
+  }
 }
 
 variable "max_spot_nodes" {
-  default = 0
+  default = {
+    az0 = 0
+    az1 = 0
+    az2 = 0
+  }
 }
 
 # nodes per az variables still work but are deprecated

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -61,15 +61,15 @@ variable "max_spot_nodes" {
 
 # nodes per az variables still work but are deprecated
 variable "min_nodes_per_az" {
-  default = 1
+  default = 0
 }
 
 variable "desired_nodes_per_az" {
-  default = 1
+  default = 0
 }
 
 variable "max_nodes_per_az" {
-  default = 2
+  default = 0
 }
 
 variable "min_spot_nodes_per_az" {
@@ -77,7 +77,7 @@ variable "min_spot_nodes_per_az" {
 }
 
 variable "max_spot_nodes_per_az" {
-  default = 2
+  default = 0
 }
 
 variable "max_spot_price" {

--- a/nodes/variables.tf
+++ b/nodes/variables.tf
@@ -22,25 +22,25 @@ variable "spot_nodes_enabled" {
 
 variable "min_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 
 variable "desired_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 
 variable "max_nodes" {
   default = {
-    az_0 = 0
-    az_1 = 0
-    az_2 = 0
+    ap-southeast-2a = 0
+    ap-southeast-2b = 0
+    ap-southeast-2c = 0
   }
 }
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- Updated nodes ASG per AZ instead multiAZ auto-scaling group to support EBS volume for jupyterhub. Also made nodes variable to configure per availability zone.

e.g.
min_spot_nodes = {
  ap-southeast-2a = 0
  ap-southeast-2b = 0
  ap-southeast-2c = 0
}

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- No impact as changes made also supports backward compatible