### PR TITLE
Additional config for cognito

### DIFF
--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -54,15 +54,15 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
-  lifecycle {
-    # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
-    # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
-    ignore_changes = [
-      "admin_create_user_config[0].unused_account_validity_days"
-    ]
-    # Enable this if you want to prevent destroy
-    #   prevent_destroy = true
-  }
+  # lifecycle {
+  #   # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
+  #   # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
+  #   ignore_changes = [
+  #     "admin_create_user_config[0].unused_account_validity_days"
+  #   ]
+  #   # Enable this if you want to prevent destroy
+  #   #   prevent_destroy = true
+  # }
 
   tags = {
     Name        = var.user_pool_name

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -54,15 +54,15 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
-  # lifecycle {
-  #   # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
-  #   # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
-  #   ignore_changes = [
-  #     "admin_create_user_config[0].unused_account_validity_days"
-  #   ]
-  #   # Enable this if you want to prevent destroy
-  #   #   prevent_destroy = true
-  # }
+  lifecycle {
+    # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
+    # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
+    ignore_changes = [
+      "admin_create_user_config[0].unused_account_validity_days"
+    ]
+    # Enable this if you want to prevent destroy
+    #   prevent_destroy = true
+  }
 
   tags = {
     Name        = var.user_pool_name

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -41,6 +41,7 @@ resource "aws_cognito_user_pool" "pool" {
     for_each = local.admin_create_user_config
     content {
       allow_admin_create_user_only = lookup(admin_create_user_config.value, "allow_admin_create_user_only")
+      unused_account_validity_days = lookup(admin_create_user_config.value, "unused_account_validity_days")
 
       dynamic "invite_message_template" {
         for_each = lookup(admin_create_user_config.value, "email_message", null) == null && lookup(admin_create_user_config.value, "email_subject", null) == null && lookup(admin_create_user_config.value, "sms_message", null) == null ? [] : [1]
@@ -74,6 +75,7 @@ locals {
   # If no admin_create_user_config list is provided, build a admin_create_user_config using the default values
   admin_create_user_config_default = {
     allow_admin_create_user_only = lookup(var.admin_create_user_config, "allow_admin_create_user_only", null) == null ? var.admin_create_user_config_allow_admin_create_user_only : lookup(var.admin_create_user_config, "allow_admin_create_user_only")
+    unused_account_validity_days = lookup(var.admin_create_user_config, "unused_account_validity_days", null) == null ? var.admin_create_user_config_unused_account_validity_days : lookup(var.admin_create_user_config, "unused_account_validity_days")
     email_message                = lookup(var.admin_create_user_config, "email_message", null) == null ? (var.email_verification_message == "" || var.email_verification_message == null ? var.admin_create_user_config_email_message : var.email_verification_message) : lookup(var.admin_create_user_config, "email_message")
     email_subject                = lookup(var.admin_create_user_config, "email_subject", null) == null ? (var.email_verification_subject == "" || var.email_verification_subject == null ? var.admin_create_user_config_email_subject : var.email_verification_subject) : lookup(var.admin_create_user_config, "email_subject")
     sms_message                  = lookup(var.admin_create_user_config, "sms_message", null) == null ? var.admin_create_user_config_sms_message : lookup(var.admin_create_user_config, "sms_message")

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -36,6 +36,25 @@ resource "aws_cognito_user_pool" "pool" {
     require_symbols   = false
   }
 
+    # admin_create_user_config
+  dynamic "admin_create_user_config" {
+    for_each = local.admin_create_user_config
+    content {
+      allow_admin_create_user_only = lookup(admin_create_user_config.value, "allow_admin_create_user_only")
+      unused_account_validity_days = lookup(admin_create_user_config.value, "unused_account_validity_days")
+
+      dynamic "invite_message_template" {
+        for_each = lookup(admin_create_user_config.value, "email_message", null) == null && lookup(admin_create_user_config.value, "email_subject", null) == null && lookup(admin_create_user_config.value, "sms_message", null) == null ? [] : [1]
+        content {
+          email_message = lookup(admin_create_user_config.value, "email_message")
+          email_subject = lookup(admin_create_user_config.value, "email_subject")
+          sms_message   = lookup(admin_create_user_config.value, "sms_message")
+        }
+      }
+    }
+  }
+
+
   # Enable this if you want to prevent destroy
   # lifecycle {
   #   prevent_destroy = true
@@ -48,6 +67,22 @@ resource "aws_cognito_user_pool" "pool" {
     Namespace   = var.namespace
     Environment = var.environment
   }
+}
+
+locals {
+
+  # admin_create_user_config
+  # If no admin_create_user_config list is provided, build a admin_create_user_config using the default values
+  admin_create_user_config_default = {
+    allow_admin_create_user_only = lookup(var.admin_create_user_config, "allow_admin_create_user_only", null) == null ? var.admin_create_user_config_allow_admin_create_user_only : lookup(var.admin_create_user_config, "allow_admin_create_user_only")
+    unused_account_validity_days = lookup(var.admin_create_user_config, "unused_account_validity_days", null) == null ? var.admin_create_user_config_unused_account_validity_days : lookup(var.admin_create_user_config, "unused_account_validity_days")
+    email_message                = lookup(var.admin_create_user_config, "email_message", null) == null ? (var.email_verification_message == "" || var.email_verification_message == null ? var.admin_create_user_config_email_message : var.email_verification_message) : lookup(var.admin_create_user_config, "email_message")
+    email_subject                = lookup(var.admin_create_user_config, "email_subject", null) == null ? (var.email_verification_subject == "" || var.email_verification_subject == null ? var.admin_create_user_config_email_subject : var.email_verification_subject) : lookup(var.admin_create_user_config, "email_subject")
+    sms_message                  = lookup(var.admin_create_user_config, "sms_message", null) == null ? var.admin_create_user_config_sms_message : lookup(var.admin_create_user_config, "sms_message")
+
+  }
+
+  admin_create_user_config = [local.admin_create_user_config_default]
 }
 
 resource "aws_cognito_user_pool_client" "client" {

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -58,7 +58,7 @@ resource "aws_cognito_user_pool" "pool" {
     # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
     # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
     ignore_changes = [
-      "admin_create_user_config.unused_account_validity_days"
+      "admin_create_user_config[0].unused_account_validity_days"
     ]
     # Enable this if you want to prevent destroy
     #   prevent_destroy = true

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -58,7 +58,7 @@ resource "aws_cognito_user_pool" "pool" {
     # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
     # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
     ignore_changes = [
-      "admin_create_user_config.0.unused_account_validity_days"
+      "admin_create_user_config.unused_account_validity_days"
     ]
     # Enable this if you want to prevent destroy
     #   prevent_destroy = true

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -56,7 +56,7 @@ resource "aws_cognito_user_pool" "pool" {
 
   lifecycle {
     # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
-    https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
+    # https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
     ignore_changes = [
       "admin_create_user_config.0.unused_account_validity_days"
     ]

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -41,7 +41,6 @@ resource "aws_cognito_user_pool" "pool" {
     for_each = local.admin_create_user_config
     content {
       allow_admin_create_user_only = lookup(admin_create_user_config.value, "allow_admin_create_user_only")
-      unused_account_validity_days = lookup(admin_create_user_config.value, "unused_account_validity_days")
 
       dynamic "invite_message_template" {
         for_each = lookup(admin_create_user_config.value, "email_message", null) == null && lookup(admin_create_user_config.value, "email_subject", null) == null && lookup(admin_create_user_config.value, "sms_message", null) == null ? [] : [1]
@@ -75,7 +74,6 @@ locals {
   # If no admin_create_user_config list is provided, build a admin_create_user_config using the default values
   admin_create_user_config_default = {
     allow_admin_create_user_only = lookup(var.admin_create_user_config, "allow_admin_create_user_only", null) == null ? var.admin_create_user_config_allow_admin_create_user_only : lookup(var.admin_create_user_config, "allow_admin_create_user_only")
-    unused_account_validity_days = lookup(var.admin_create_user_config, "unused_account_validity_days", null) == null ? var.admin_create_user_config_unused_account_validity_days : lookup(var.admin_create_user_config, "unused_account_validity_days")
     email_message                = lookup(var.admin_create_user_config, "email_message", null) == null ? (var.email_verification_message == "" || var.email_verification_message == null ? var.admin_create_user_config_email_message : var.email_verification_message) : lookup(var.admin_create_user_config, "email_message")
     email_subject                = lookup(var.admin_create_user_config, "email_subject", null) == null ? (var.email_verification_subject == "" || var.email_verification_subject == null ? var.admin_create_user_config_email_subject : var.email_verification_subject) : lookup(var.admin_create_user_config, "email_subject")
     sms_message                  = lookup(var.admin_create_user_config, "sms_message", null) == null ? var.admin_create_user_config_sms_message : lookup(var.admin_create_user_config, "sms_message")

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -54,11 +54,15 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
-
-  # Enable this if you want to prevent destroy
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
+  lifecycle {
+    # Hack to workaround issue with AWS changing approach and TF AWS Provider not having been updated yet.
+    https://github.com/terraform-providers/terraform-provider-aws/issues/8827#issuecomment-567041332
+    ignore_changes = [
+      "admin_create_user_config.0.unused_account_validity_days"
+    ]
+    # Enable this if you want to prevent destroy
+    #   prevent_destroy = true
+  }
 
   tags = {
     Name        = var.user_pool_name

--- a/cognito/output.tf
+++ b/cognito/output.tf
@@ -1,6 +1,3 @@
-output "userpool" {
-  value = aws_cognito_user_pool.pool.name
-}
 
 output "userpool_id" {
   value = aws_cognito_user_pool.pool.id

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -65,20 +65,20 @@ variable "admin_create_user_config_unused_account_validity_days" {
 variable "admin_create_user_config_email_message" {
   description = "The message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
   type        = string
-  default     = "{username}, your verification code is `{####}`"
+  default     = null
 }
 
 
 variable "admin_create_user_config_email_subject" {
   description = "The subject line for email messages"
   type        = string
-  default     = "Your verification code"
+  default     = null
 }
 
 variable "admin_create_user_config_sms_message" {
   description = "- The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
   type        = string
-  default     = "Your username is {username} and temporary password is `{####}`"
+  default     = null
 }
 
 variable "email_verification_message" {

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -56,6 +56,12 @@ variable "admin_create_user_config_allow_admin_create_user_only" {
   default     = false
 }
 
+variable "admin_create_user_config_unused_account_validity_days" {
+  description = "The user account expiration limit, in days, after which the account is no longer usable"
+  type        = number
+  default     = 7
+}
+
 variable "admin_create_user_config_email_message" {
   description = "The message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
   type        = string

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -59,7 +59,7 @@ variable "admin_create_user_config_allow_admin_create_user_only" {
 variable "admin_create_user_config_unused_account_validity_days" {
   description = "The user account expiration limit, in days, after which the account is no longer usable"
   type        = number
-  default     = 7
+  default     = 0
 }
 
 variable "admin_create_user_config_email_message" {

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -80,3 +80,16 @@ variable "admin_create_user_config_sms_message" {
   type        = string
   default     = "Your username is {username} and temporary password is `{####}`"
 }
+
+variable "email_verification_message" {
+  description = "A string representing the email verification message"
+  type        = string
+  default     = null
+}
+
+variable "email_verification_subject" {
+  description = "A string representing the email verification subject"
+  type        = string
+  default     = null
+}
+

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -56,12 +56,6 @@ variable "admin_create_user_config_allow_admin_create_user_only" {
   default     = false
 }
 
-variable "admin_create_user_config_unused_account_validity_days" {
-  description = "The user account expiration limit, in days, after which the account is no longer usable"
-  type        = number
-  default     = 7
-}
-
 variable "admin_create_user_config_email_message" {
   description = "The message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
   type        = string

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -42,3 +42,41 @@ variable "namespace" {
 
 variable "owner" {
 }
+
+# admin_create_user_config
+variable "admin_create_user_config" {
+  description = "The configuration for AdminCreateUser requests"
+  type        = map
+  default     = {}
+}
+
+variable "admin_create_user_config_allow_admin_create_user_only" {
+  description = "Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app"
+  type        = bool
+  default     = false
+}
+
+variable "admin_create_user_config_unused_account_validity_days" {
+  description = "The user account expiration limit, in days, after which the account is no longer usable"
+  type        = number
+  default     = 7
+}
+
+variable "admin_create_user_config_email_message" {
+  description = "The message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
+  type        = string
+  default     = "{username}, your verification code is `{####}`"
+}
+
+
+variable "admin_create_user_config_email_subject" {
+  description = "The subject line for email messages"
+  type        = string
+  default     = "Your verification code"
+}
+
+variable "admin_create_user_config_sms_message" {
+  description = "- The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
+  type        = string
+  default     = "Your username is {username} and temporary password is `{####}`"
+}

--- a/examples/stage/odc_k8s_sandbox/config/jhub.yaml
+++ b/examples/stage/odc_k8s_sandbox/config/jhub.yaml
@@ -14,9 +14,9 @@ hub:
     JUPYTERHUB_USERPOOL_ID: ${jhub_userpool_id}
     AWS_DEFAULT_REGION: ${region}
     OAUTH_CALLBACK_URL: https://app.${domain_name}/oauth_callback
-    OAUTH2_AUTHORIZE_URL: https://${jhub_userpool_doamin}.auth.${region}.amazoncognito.com/oauth2/authorize
-    OAUTH2_TOKEN_URL: https://${jhub_userpool_doamin}.auth.${region}.amazoncognito.com/oauth2/token
-    OAUTH2_USERDATA_URL: https://${jhub_userpool_doamin}.auth.${region}.amazoncognito.com/oauth2/userInfo
+    OAUTH2_AUTHORIZE_URL: https://${jhub_userpool_domain}.auth.${region}.amazoncognito.com/oauth2/authorize
+    OAUTH2_TOKEN_URL: https://${jhub_userpool_domain}.auth.${region}.amazoncognito.com/oauth2/token
+    OAUTH2_USERDATA_URL: https://${jhub_userpool_domain}.auth.${region}.amazoncognito.com/oauth2/userInfo
   cookieSecret: 65732236ed9aca1180053b99f1d43382eba09bd7bc5c401804959127a80f774c # Replace
 scheduling:
   userPods:

--- a/examples/stage/odc_k8s_sandbox/jhub.tf
+++ b/examples/stage/odc_k8s_sandbox/jhub.tf
@@ -12,7 +12,7 @@ data "template_file" "jhub" {
     db_password = local.db_password
     db_name     = local.db_name
     jhub_userpool_id        = local.jhub_userpool_id
-    jhub_userpool_doamin    = local.jhub_userpool_doamin
+    jhub_userpool_domain    = local.jhub_userpool_domain
     jhub_auth_client_id     = local.jhub_auth_client_id
     jhub_auth_client_secret = local.jhub_auth_client_secret
   }

--- a/examples/stage/odc_k8s_sandbox/odc_k8s_data_providers.tf
+++ b/examples/stage/odc_k8s_sandbox/odc_k8s_data_providers.tf
@@ -41,9 +41,8 @@ locals {
   domain_name     = data.terraform_remote_state.odc_eks-stage.outputs.domain_name
   certificate_arn = tolist(data.terraform_remote_state.odc_eks-stage.outputs.certificate_arn)[0]
 
-  jhub_userpool           = module.jhub_cognito_auth.userpool
   jhub_userpool_id        = module.jhub_cognito_auth.userpool_id
-  jhub_userpool_doamin    = module.jhub_cognito_auth.userpool_domain
+  jhub_userpool_domain    = module.jhub_cognito_auth.userpool_domain
   jhub_auth_client_id     = module.jhub_cognito_auth.client_id
   jhub_auth_client_secret = module.jhub_cognito_auth.client_secret
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

This modification allows for the email message being sent when admins create account to be customised.
NOTE: AWS Cognito has changed it parameters for the validity of unused temporary passwords and at the moment the tf AWS provider doesn't support this parameter. As a result it is necessary to use a workaround that prevents TF from doing anything with that value. The module has been configured with that workaround. See the code changes for a link to the details.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

The module includes a default configuration in the event one isn't provided. It's very nearly the same behaviour so there shouldn't be any side effects but its difficult to tell given it depends on the current state of your AWS infrastructure.