### PR TITLE
added new module odc_user to support creating IAM user

### DIFF
--- a/odc_user/output.tf
+++ b/odc_user/output.tf
@@ -1,0 +1,9 @@
+output "id" {
+  value = aws_iam_access_key.user.id
+  sensitive = true
+}
+
+output "secret" {
+  value = aws_iam_access_key.user.secret
+  sensitive = true
+}

--- a/odc_user/user.tf
+++ b/odc_user/user.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_user" "user" {
+  name = var.user.name
+  path = "/"
+
+  tags = merge(
+    {
+      name = var.user.name
+      owner = var.owner
+      namespace = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+resource "aws_iam_access_key" "user" {
+  user = aws_iam_user.user.name
+}
+
+resource "aws_iam_user_policy" "jhub_user_ro" {
+  name = "${var.user.name}-policy"
+  user = aws_iam_user.user.name
+  policy = var.user.policy
+}

--- a/odc_user/variables.tf
+++ b/odc_user/variables.tf
@@ -1,0 +1,28 @@
+variable "namespace" {
+  type = string
+  description = "The name used for creation of backend resources like the terraform state bucket"
+  default = "odc-test"
+}
+
+variable "owner" {
+  type = string
+  description = "The owner of the environment"
+  default = "odc-test"
+}
+
+variable "environment" {
+  type = string
+  description = "The name of the environment - e.g. dev, stage, prod"
+  default = "stage"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+  default     = {}
+}
+
+variable "user" {
+  type        = map
+  description = "Provision a user that can be used by pods/applications on the k8s cluster"
+}


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- created odc_user module - this will use to provision user and sets its policy.

usage:

```
module "odc_user_jupyterhub" {
  source = "github.com/opendatacube/datacube-k8s-eks//odc_user?ref=new-odc-user-module"
  
  # Default tags
  owner = local.owner
  namespace = local.namespace
  environment = local.environment

  # To setup additional tags
  tags = {
    "stack_name" = local.cluster_id
    "department" = "geoscience australia"
  }

  user = {
    name = "test-user"
    policy = <<-EOF
    {
      "Version": "2012-10-17",
      "Statement": [
        {
          "Effect": "Allow",
          "Action": [
              "S3:ListBucket"
          ],
          "Resource": [
            "arn:aws:s3:::dea-public-data"
          ]
        }
    EOF
  }
}
```

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here
