### PR TITLE
pin helm provider version to 0.10.4 - newer version is not supporting tiller

### DIFF
--- a/addons/main.tf
+++ b/addons/main.tf
@@ -15,6 +15,8 @@ data "aws_caller_identity" "current" {
 }
 
 provider "helm" {
+  # The latest helm release 1.0.0 has a breaking change that removes support for Helm 2 and tiller.
+  version = "0.10.4"
   kubernetes {
     config_context = data.aws_eks_cluster.eks.arn
   }


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Newer version of helm provider not supporting tiller so need to pin the version -> 0.10.4

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

Fix helm provider - pipeline broken