### PR TITLE
add a variable to prevent destroy cognito

### DIFF
--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -60,8 +60,8 @@ resource "aws_cognito_user_pool" "pool" {
     ignore_changes = [
       "admin_create_user_config[0].unused_account_validity_days"
     ]
-    # Enable this if you want to prevent destroy
-    #   prevent_destroy = true
+    # Enable prevent destroy
+    prevent_destroy = var.prevent_destroy
   }
 
   tags = {

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -76,7 +76,7 @@ variable "admin_create_user_config_email_subject" {
 }
 
 variable "admin_create_user_config_sms_message" {
-  description = "- The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
+  description = "The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively"
   type        = string
   default     = null
 }
@@ -91,5 +91,11 @@ variable "email_verification_subject" {
   description = "A string representing the email verification subject"
   type        = string
   default     = null
+}
+
+variable "prevent_destroy" {
+  type = bool
+  description = "Whether to prevent destroy cognito. Default is set to false and delete cognito on terraform destroy."
+  default = false
 }
 


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Enable cognito prevent destroy option

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No imapact. Default is set to false and it will destroy cognito same as current setup.