### PR TITLE
update cognito app client settings for callback_urls, default_redirect_uri and logout_urls

### DIFF
--- a/cognito/README.md
+++ b/cognito/README.md
@@ -69,7 +69,10 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | namespace | The unique namespace for the environment, which could be your organization name or abbreviation, e.g. 'odc' | string |  | yes |
 | environment | The name of the environment - e.g. dev, stage | string |  | yes |
 | auto_verify | Set to true to allow the user account to be auto verified. False - admin will need to verify | bool | | yes |
-| callback_url | The callback url for your application | string | | yes |
+| callback_url | **Deprecated Var** - The callback url for your application | list(string) | | no |
+| callback_urls | List of allowed callback URLs for the identity providers | list(string) | | yes |
+| default_redirect_uri | The default redirect URI. Must be in the list of callback URLs | string | | no |
+| logout_urls | List of allowed logout URLs for the identity providers | list(string) | | no |
 | user_pool_name | The cognito user pool name | string | | yes |
 | user_pool_domain | The cognito user pool domain | string | | yes |
 | user_groups | List of user groups manage by cognito user pool | List | [] | no |

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -96,7 +96,9 @@ resource "aws_cognito_user_pool_client" "client" {
   user_pool_id = aws_cognito_user_pool.pool.id
   generate_secret     = true
   supported_identity_providers = ["COGNITO"]
-  callback_urls =[var.callback_url]
+  callback_urls = (var.callback_url != "") ? [var.callback_url] : var.callback_urls
+  default_redirect_uri = var.default_redirect_uri
+  logout_urls = var.logout_urls
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes = ["email", "aws.cognito.signin.user.admin", "openid"]
   allowed_oauth_flows = ["code"]

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -1,6 +1,25 @@
 variable "callback_url" {
   type = string
-  description = "The callback url for your application"
+  description = "**Deprecated Var** - The callback url for your application"
+  default = ""
+}
+
+variable "callback_urls" {
+  type = list(string)
+  description = "List of allowed callback URLs for the identity providers"
+  default = []
+}
+
+variable "default_redirect_uri" {
+  type = string
+  description = "The default redirect URI. Must be in the list of callback URLs"
+  default = ""
+}
+
+variable "logout_urls" {
+  type = list(string)
+  description = "List of allowed logout URLs for the identity providers"
+  default = []
 }
 
 variable "user_pool_name" {


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- Cognit module enhancement - update cognito app client settings so we can experiment with jupyterhub enhancement/upgrade work. Looking into upgrading latest chart release, cognito authenticator class (https://github.com/jupyterhub/oauthenticator/pull/269/files) and few other enhancements 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- No impact. Changes are made such that it works with older version of the cognito module. But recommending  to make necessary changes as we progressing with odc-1.8.

** Recommendation **
- use `callback_urls` instead of `callback_url` which accepts lists of urls.
- `default_redirect_uri` and `logout_urls` are optional parameters.
 Note: Good to configure these params if you want to use `AWSCognitoAuthenticator` class for `sandbox` authenticator. Currently under dev testing. Will update an example once we finish testing.
