### PR TITLE
updated WAF module source to point to ODC fork

### DIFF
--- a/odc_eks/README.md
+++ b/odc_eks/README.md
@@ -182,6 +182,22 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | waf_max_expected_body_size | Maximum number of bytes allowed in the body of the request | string | "536870912" | No |
 | waf_firehose_buffer_size | Buffer incoming data to the specified size, in MBs, before delivering it to the destination. Valid value is between 64-128 | string | "128" | No |
 | waf_firehose_buffer_interval | Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. Valid value is between 60-900 | string | "900" | No |
+| waf_disable_03_uri_url_decode | Disable the 'URI contains a cross-site scripting threat after decoding as URL.' filter | bool | false | No |
+| waf_disable_03_uri_html_decode | Disable the 'URI contains a cross-site scripting threat after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_03_query_string_url_decode | Disable the 'Query string contains a cross-site scripting threat after decoding as URL.' filter | bool | false | No |
+| waf_disable_03_query_string_html_decode | Disable the 'Query string contains a cross-site scripting threat after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_03_body_url_decode | Disable the 'Body contains a cross-site scripting threat after decoding as URL.' filter | bool | false | No |
+| waf_disable_03_body_html_decode | Disable the 'Body contains a cross-site scripting threat after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_03_cookie_url_decode | Disable the 'Header cookie contains a cross-site scripting threat after decoding as URL.' filter | bool | false | No |
+| waf_disable_03_cookie_html_decode | Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_04_uri_contains_previous_dir_after_url_decode | Disable the 'URI contains: '../' after decoding as URL.' filter | bool | false | No |
+| waf_disable_04_uri_contains_previous_dir_after_html_decode | Disable the 'URI contains: '../' after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_04_query_string_contains_previous_dir_after_url_decode | Disable the 'Query string contains: '../' after decoding as URL.' filter | bool | false | No |
+| waf_disable_04_query_string_contains_previous_dir_after_html_decode | Disable the 'Query string contains: '../' after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_04_uri_contains_url_path_after_url_decode | Disable the 'URI contains: '://' after decoding as URL.' filter | bool | false | No |
+| waf_disable_04_uri_contains_url_path_after_html_decode | Disable the 'URI contains: '://' after decoding as HTML tags.' filter | bool | false | No |
+| waf_disable_04_query_string_contains_url_path_after_url_decode | Disable the 'Query string contains: '://' after decoding as URL.' filter | bool | false | No |
+| waf_disable_04_query_string_contains_url_path_after_html_decode | Disable the 'Query string contains: '://' after decoding as HTML tags.' filter | bool | false | No |
 
 #### ACM
 | Name | Description | Type | Default | Required |

--- a/odc_eks/README.md
+++ b/odc_eks/README.md
@@ -29,6 +29,10 @@ This is useful if migration is being performed to deploy a new infrastructure wi
 - Setup AWS WAF for web application security for web application.
 - Issue a domain certificate using AWS Certificate Manager. It uses Route53 to validate certificate. 
 
+### WAF Important Consideration
+- If you are using WAF for `jupyterhub` setup, make sure to disable `waf_disable_03_body_url_decode` and `waf_disable_03_body_html_decode` 
+filter to allow users to compose and save jupyterhub `notebooks` that contains rich HTML contents.
+
 ## Usage
 
 The complete Open Data Cube terraform AWS example is provided for kick start [here](https://github.com/opendatacube/datacube-k8s-eks/tree/terraform-aws-odc/examples/stage).

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -41,6 +41,104 @@ variable "waf_firehose_buffer_interval" {
   default     = "900"
 }
 
+# NOTE: variables to manage cross-site scripting filters
+variable "waf_disable_03_uri_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "waf_disable_03_uri_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+variable "waf_disable_03_query_string_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "waf_disable_03_query_string_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+variable "waf_disable_03_body_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Body contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "waf_disable_03_body_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Body contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+variable "waf_disable_03_cookie_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Header cookie contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "waf_disable_03_cookie_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+# NOTE: variables to manage dangerous HTTP request patterns filters, e.g. path traversal attempts
+variable "waf_disable_04_uri_contains_previous_dir_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '../' after decoding as URL.' filter"
+}
+
+variable "waf_disable_04_uri_contains_previous_dir_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '../' after decoding as HTML tags.' filter"
+}
+
+variable "waf_disable_04_query_string_contains_previous_dir_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '../' after decoding as URL.' filter"
+}
+
+variable "waf_disable_04_query_string_contains_previous_dir_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '../' after decoding as HTML tags.' filter"
+}
+
+variable "waf_disable_04_uri_contains_url_path_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '://' after decoding as URL.' filter"
+}
+
+variable "waf_disable_04_uri_contains_url_path_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '://' after decoding as HTML tags.' filter"
+}
+
+variable "waf_disable_04_query_string_contains_url_path_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '://' after decoding as URL.' filter"
+}
+
+variable "waf_disable_04_query_string_contains_url_path_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '://' after decoding as HTML tags.' filter"
+}
+
 module "waf_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
   namespace  = var.namespace
@@ -49,12 +147,13 @@ module "waf_label" {
   delimiter  = "-"
 }
 
-# The module which is defined on repository: https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules
-# For a better understanding of what are those parameters mean,
-# please read the description of each variable in the variables.tf file:
-# https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/blob/master/variables.tf
+# Module: https://github.com/masterpointio/terraform-aws-waf-owasp-top-10-rules
+# The module is a fork from repository: https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules
+# PR raised to support below features: https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/pull/17
+# - Updates to address all Terraform 0.12 warnings
+# - Updates to allow disable specific XSS and  rules
 module "owasp_top_10_rules" {
-  source = "git::https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules.git?ref=v0.2.0"
+  source = "git::https://github.com/masterpointio/terraform-aws-waf-owasp-top-10-rules.git?ref=master"
   # The TF registry syntax is proving unreliable for downloads. Using direct github link to get module
   # source  = "traveloka/waf-owasp-top-10-rules/aws"
   # version = "v0.2.0"
@@ -74,6 +173,26 @@ module "owasp_top_10_rules" {
 
   csrf_expected_header = "x-csrf-token"
   csrf_expected_size   = "36"
+
+  # NOTE: variables to manage cross-site scripting filters
+  disable_03_uri_url_decode           = var.waf_disable_03_uri_url_decode
+  disable_03_uri_html_decode          = var.waf_disable_03_uri_html_decode
+  disable_03_query_string_url_decode  = var.waf_disable_03_query_string_url_decode
+  disable_03_query_string_html_decode = var.waf_disable_03_query_string_html_decode
+  disable_03_body_url_decode          = var.waf_disable_03_body_url_decode
+  disable_03_body_html_decode         = var.waf_disable_03_body_html_decode
+  disable_03_cookie_url_decode        = var.waf_disable_03_cookie_url_decode
+  disable_03_cookie_html_decode       = var.waf_disable_03_cookie_html_decode
+
+  # NOTE: variables to manage dangerous HTTP request patterns filters, e.g. path traversal attempts
+  disable_04_uri_contains_previous_dir_after_url_decode           = var.waf_disable_04_uri_contains_previous_dir_after_url_decode
+  disable_04_uri_contains_previous_dir_after_html_decode          = var.waf_disable_04_uri_contains_previous_dir_after_html_decode
+  disable_04_query_string_contains_previous_dir_after_url_decode  = var.waf_disable_04_query_string_contains_previous_dir_after_url_decode
+  disable_04_query_string_contains_previous_dir_after_html_decode = var.waf_disable_04_query_string_contains_previous_dir_after_html_decode
+  disable_04_uri_contains_url_path_after_url_decode               = var.waf_disable_04_uri_contains_url_path_after_url_decode
+  disable_04_uri_contains_url_path_after_html_decode              = var.waf_disable_04_uri_contains_url_path_after_html_decode
+  disable_04_query_string_contains_url_path_after_url_decode      = var.waf_disable_04_query_string_contains_url_path_after_url_decode
+  disable_04_query_string_contains_url_path_after_html_decode     = var.waf_disable_04_query_string_contains_url_path_after_html_decode
 }
 
 /*

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -147,13 +147,14 @@ module "waf_label" {
   delimiter  = "-"
 }
 
-# Module: https://github.com/masterpointio/terraform-aws-waf-owasp-top-10-rules
-# The module is a fork from repository: https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules
-# PR raised to support below features: https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/pull/17
+# Module: https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules
+# The module is a fork from repository: https://github.com/masterpointio/terraform-aws-waf-owasp-top-10-rules
+# This is an extention of the main repo: https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/pull/17
+# This module extends the main repo to solve -
 # - Updates to address all Terraform 0.12 warnings
 # - Updates to allow disable specific XSS and  rules
 module "owasp_top_10_rules" {
-  source = "git::https://github.com/masterpointio/terraform-aws-waf-owasp-top-10-rules.git?ref=master"
+  source = "git::https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules.git?ref=master"
   # The TF registry syntax is proving unreliable for downloads. Using direct github link to get module
   # source  = "traveloka/waf-owasp-top-10-rules/aws"
   # version = "v0.2.0"

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -45,49 +45,49 @@ variable "waf_firehose_buffer_interval" {
 variable "waf_disable_03_uri_url_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'URI contains a cross-site scripting threat after decoding as URL.' filter."
+  description = "Disable the 'URI contains a cross-site scripting threat after decoding as URL.' filter"
 }
 
 variable "waf_disable_03_uri_html_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'URI contains a cross-site scripting threat after decoding as HTML tags.' filter."
+  description = "Disable the 'URI contains a cross-site scripting threat after decoding as HTML tags.' filter"
 }
 
 variable "waf_disable_03_query_string_url_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as URL.' filter."
+  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as URL.' filter"
 }
 
 variable "waf_disable_03_query_string_html_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as HTML tags.' filter."
+  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as HTML tags.' filter"
 }
 
 variable "waf_disable_03_body_url_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'Body contains a cross-site scripting threat after decoding as URL.' filter."
+  description = "Disable the 'Body contains a cross-site scripting threat after decoding as URL.' filter"
 }
 
 variable "waf_disable_03_body_html_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'Body contains a cross-site scripting threat after decoding as HTML tags.' filter."
+  description = "Disable the 'Body contains a cross-site scripting threat after decoding as HTML tags.' filter"
 }
 
 variable "waf_disable_03_cookie_url_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'Header cookie contains a cross-site scripting threat after decoding as URL.' filter."
+  description = "Disable the 'Header cookie contains a cross-site scripting threat after decoding as URL.' filter"
 }
 
 variable "waf_disable_03_cookie_html_decode" {
   default     = false
   type        = bool
-  description = "Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter."
+  description = "Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter"
 }
 
 # NOTE: variables to manage dangerous HTTP request patterns filters, e.g. path traversal attempts
@@ -155,9 +155,6 @@ module "waf_label" {
 # - Updates to allow disable specific XSS and  rules
 module "owasp_top_10_rules" {
   source = "git::https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules.git?ref=master"
-  # The TF registry syntax is proving unreliable for downloads. Using direct github link to get module
-  # source  = "traveloka/waf-owasp-top-10-rules/aws"
-  # version = "v0.2.0"
 
   product_domain = var.namespace
   service_name   = "wafowasp"


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

current`01_odc_eks/waf.tf` uses module created by [`traveloka/terraform-aws-waf-owasp-top-10-rules`](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules) has two issues - 
- module is written using terraform version < 0.12 and throws warning 
- Cross-site scripting is currently stoping user to save notebook files and we cannot disable the XSS filters because it doesn't support optional rule creation - check [FAQ](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules#faq). 

To fix this problem, created a ODC fork from [PR](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/pull/17) created by `Matt Gowie`. This  PR exactly does what we after and resolves our problem statement too. 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No impact. Additional variables to disable XSS filters. By default it is set to false so no impact.