### PR TITLE
added support to create additional user pool clients to manage multiple apps

### DIFF
--- a/cognito/README.md
+++ b/cognito/README.md
@@ -32,7 +32,6 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
     auto_verify = true
     user_pool_name       = "odc-stage-cluster-jhub-userpool"
     user_pool_domain     = "odc-stage-cluster-jhub-auth"
-    callback_url         = "https://app.example.domain.com/oauth_callback"
     user_groups = [
       {
         name        = "dev-group"
@@ -45,20 +44,20 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
         precedence  = 10
       }
     ]
-    additional_clients = [
+    app_clients = [
       {
-        name          = "app1-client"
+        name          = "sandbox-client"
         callback_urls = [
-          "https://app1.example.domain.com/oauth_callback",
-          "https://app1.example.domain.com"
+          "https://app.sandbox.example.com/oauth_callback",
+          "https://app.sandbox.example.com"
         ]
         logout_urls   = [
-          "https://app1.example.domain.com"
+          "https://app.sandbox.example.com"
         ]
-        default_redirect_uri = "https://app1.example.domain.com"
-        explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH"]
-    }
-  ]
+        default_redirect_uri = "app.sandbox.example.com"
+        explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_CUSTOM_AUTH"]
+      }
+    ]
     
     # Default tags + resource labels
     owner           = "odc-owner"
@@ -84,13 +83,13 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | environment | The name of the environment - e.g. dev, stage | string |  | yes |
 | auto_verify | Set to true to allow the user account to be auto verified. False - admin will need to verify | bool | | yes |
 | callback_url | **Deprecated Var** - The callback url for your application | list(string) | | no |
-| callback_urls | List of allowed callback URLs for the identity providers | list(string) | | yes |
-| default_redirect_uri | The default redirect URI. Must be in the list of callback URLs | string | | no |
-| logout_urls | List of allowed logout URLs for the identity providers | list(string) | | no |
+| callback_urls | **Deprecated Var** - List of allowed callback URLs for the identity providers | list(string) | | yes |
+| default_redirect_uri | **Deprecated Var** - The default redirect URI. Must be in the list of callback URLs | string | | no |
+| logout_urls | **Deprecated Var** - List of allowed logout URLs for the identity providers | list(string) | | no |
+| app_clients | List of user pool app clients to support multiple applications | List(object({name = string,callback_urls = list(string),logout_urls = list(string),default_redirect_uri = string,explicit_auth_flows = list(string)})) | [] | no |
 | user_pool_name | The cognito user pool name | string | | yes |
 | user_pool_domain | The cognito user pool domain | string | | yes |
 | user_groups | List of user groups manage by cognito user pool | list(object({name = string,description = string,precedence = number})) | [] | no |
-| additional_clients | List of additional user pool client to support multiple applications | List(object({name = string,callback_urls = list(string),logout_urls = list(string),default_redirect_uri = string,explicit_auth_flows = list(string)})) | [] | no |
 | admin_create_user_config | The configuration for AdminCreateUser requests | map | {} | no |
 | admin_create_user_config_allow_admin_create_user_only | Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app | bool | false | No | 
 | admin_create_user_config_unused_account_validity_days | The user account expiration limit, in days, after which the account is no longer usable | number | 0 | No |

--- a/cognito/README.md
+++ b/cognito/README.md
@@ -35,16 +35,30 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
     callback_url         = "https://app.example.domain.com/oauth_callback"
     user_groups = [
       {
-          name        = "dev-group"
-          description = "Group defines Jupyterhub dev users"
-          precedence  = 5
+        name        = "dev-group"
+        description = "Group defines Jupyterhub dev users"
+        precedence  = 5
       },
       {
-          name        = "default-group"
-          description = "Group defines Jupyterhub default users"
-          precedence  = 10
+        name        = "default-group"
+        description = "Group defines Jupyterhub default users"
+        precedence  = 10
       }
     ]
+    additional_clients = [
+      {
+        name          = "app1-client"
+        callback_urls = [
+          "https://app1.example.domain.com/oauth_callback",
+          "https://app1.example.domain.com"
+        ]
+        logout_urls   = [
+          "https://app1.example.domain.com"
+        ]
+        default_redirect_uri = "https://app1.example.domain.com"
+        explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH"]
+    }
+  ]
     
     # Default tags + resource labels
     owner           = "odc-owner"
@@ -75,7 +89,8 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | logout_urls | List of allowed logout URLs for the identity providers | list(string) | | no |
 | user_pool_name | The cognito user pool name | string | | yes |
 | user_pool_domain | The cognito user pool domain | string | | yes |
-| user_groups | List of user groups manage by cognito user pool | List | [] | no |
+| user_groups | List of user groups manage by cognito user pool | list(object({name = string,description = string,precedence = number})) | [] | no |
+| additional_clients | List of additional user pool client to support multiple applications | List(object({name = string,callback_urls = list(string),logout_urls = list(string),default_redirect_uri = string,explicit_auth_flows = list(string)})) | [] | no |
 | admin_create_user_config | The configuration for AdminCreateUser requests | map | {} | no |
 | admin_create_user_config_allow_admin_create_user_only | Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app | bool | false | No | 
 | admin_create_user_config_unused_account_validity_days | The user account expiration limit, in days, after which the account is no longer usable | number | 0 | No |

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -91,7 +91,9 @@ locals {
   admin_create_user_config = [local.admin_create_user_config_default]
 }
 
+# TODO: remove me! - This resource is deprecated. only kept to support v1.8.0 release.
 resource "aws_cognito_user_pool_client" "client" {
+  count = (length(var.app_clients) == 0) ? 1 : 0
   name = "client"
   user_pool_id = aws_cognito_user_pool.pool.id
   generate_secret     = true
@@ -104,17 +106,17 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_flows = ["code"]
 }
 
-resource "aws_cognito_user_pool_client" "additional_clients" {
-  count           = length(var.additional_clients)
-  name            = var.additional_clients[count.index].name
+resource "aws_cognito_user_pool_client" "clients" {
+  count           = length(var.app_clients)
+  name            = var.app_clients[count.index].name
   user_pool_id    = aws_cognito_user_pool.pool.id
   generate_secret = true
   supported_identity_providers = ["COGNITO"]
 
-  callback_urls        = var.additional_clients[count.index].callback_urls
-  default_redirect_uri = var.additional_clients[count.index].default_redirect_uri
-  logout_urls          = var.additional_clients[count.index].logout_urls
-  explicit_auth_flows  = var.additional_clients[count.index].explicit_auth_flows
+  callback_urls        = var.app_clients[count.index].callback_urls
+  default_redirect_uri = var.app_clients[count.index].default_redirect_uri
+  logout_urls          = var.app_clients[count.index].logout_urls
+  explicit_auth_flows  = var.app_clients[count.index].explicit_auth_flows
 
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes = ["email", "aws.cognito.signin.user.admin", "openid"]

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -104,6 +104,23 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_flows = ["code"]
 }
 
+resource "aws_cognito_user_pool_client" "additional_clients" {
+  count           = length(var.additional_clients)
+  name            = var.additional_clients[count.index].name
+  user_pool_id    = aws_cognito_user_pool.pool.id
+  generate_secret = true
+  supported_identity_providers = ["COGNITO"]
+
+  callback_urls        = var.additional_clients[count.index].callback_urls
+  default_redirect_uri = var.additional_clients[count.index].default_redirect_uri
+  logout_urls          = var.additional_clients[count.index].logout_urls
+  explicit_auth_flows  = var.additional_clients[count.index].explicit_auth_flows
+
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_scopes = ["email", "aws.cognito.signin.user.admin", "openid"]
+  allowed_oauth_flows = ["code"]
+}
+
 resource "aws_cognito_user_pool_domain" "domain" {
   domain       = var.user_pool_domain
   user_pool_id = aws_cognito_user_pool.pool.id

--- a/cognito/output.tf
+++ b/cognito/output.tf
@@ -26,7 +26,6 @@ output "client_ids" {
 }
 
 output "client_secrets" {
-  //  value = (length(var.app_clients) == 0)? aws_cognito_user_pool_client.client[0].client_secret : null
   value = (length(var.app_clients) > 0) ? aws_cognito_user_pool_client.clients.*.client_secret : null
   sensitive = true
 }

--- a/cognito/output.tf
+++ b/cognito/output.tf
@@ -8,12 +8,25 @@ output "userpool_domain" {
   value = aws_cognito_user_pool_domain.domain.domain
 }
 
+# TODO: remove me! - This is deprecated.
 output "client_id" {
-  value = aws_cognito_user_pool_client.client.id
+  value = (length(var.app_clients) == 0)? aws_cognito_user_pool_client.client[0].id : null
   sensitive = true
 }
 
+# TODO: remove me! - This is deprecated.
 output "client_secret" {
-  value = aws_cognito_user_pool_client.client.client_secret
+  value = (length(var.app_clients) == 0)? aws_cognito_user_pool_client.client[0].client_secret : null
+  sensitive = true
+}
+
+output "client_ids" {
+  value = (length(var.app_clients) > 0) ? aws_cognito_user_pool_client.clients.*.id : null
+  sensitive = true
+}
+
+output "client_secrets" {
+  //  value = (length(var.app_clients) == 0)? aws_cognito_user_pool_client.client[0].client_secret : null
+  value = (length(var.app_clients) > 0) ? aws_cognito_user_pool_client.clients.*.client_secret : null
   sensitive = true
 }

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -4,22 +4,37 @@ variable "callback_url" {
   default = ""
 }
 
+# TODO: remove me! - This is deprecated. Use `app_clients` var instead.
 variable "callback_urls" {
   type = list(string)
   description = "List of allowed callback URLs for the identity providers"
   default = []
 }
 
+# TODO: remove me! - This is deprecated. Use `app_clients` var instead.
 variable "default_redirect_uri" {
   type = string
   description = "The default redirect URI. Must be in the list of callback URLs"
   default = ""
 }
 
+# TODO: remove me! - This is deprecated. Use `app_clients` var instead.
 variable "logout_urls" {
   type = list(string)
   description = "List of allowed logout URLs for the identity providers"
   default = []
+}
+
+variable "app_clients" {
+  default = []
+  description = "List of user pool app clients to support multiple applications"
+  type = list(object({
+    name = string
+    callback_urls = list(string)
+    logout_urls = list(string)
+    default_redirect_uri = string
+    explicit_auth_flows = list(string)
+  }))
 }
 
 variable "user_pool_name" {
@@ -39,18 +54,6 @@ variable "user_groups" {
     name = string
     description = string
     precedence = number
-  }))
-}
-
-variable "app_clients" {
-  default = []
-  description = "List of user pool app clients to support multiple applications"
-  type = list(object({
-    name = string
-    callback_urls = list(string)
-    logout_urls = list(string)
-    default_redirect_uri = string
-    explicit_auth_flows = list(string)
   }))
 }
 

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -42,9 +42,9 @@ variable "user_groups" {
   }))
 }
 
-variable "additional_clients" {
+variable "app_clients" {
   default = []
-  description = "List of additional user pool client to support multiple applications"
+  description = "List of user pool app clients to support multiple applications"
   type = list(object({
     name = string
     callback_urls = list(string)

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -42,6 +42,18 @@ variable "user_groups" {
   }))
 }
 
+variable "additional_clients" {
+  default = []
+  description = "List of additional user pool client to support multiple applications"
+  type = list(object({
+    name = string
+    callback_urls = list(string)
+    logout_urls = list(string)
+    default_redirect_uri = string
+    explicit_auth_flows = list(string)
+  }))
+}
+
 variable "auto_verify" {
   description = "Set to true to allow the users account to be auto verified. False - admin will need to verify"
   type = bool


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- We wanted use same cognito user pool for multiple applications, e.g. jupyterhub, airflow. This allows us to manage users who can have access to multiple applications using same user account.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- No impact. Introduce new variable `app_clients` to configure user pool app clients. check the README `usage`. 