### PR TITLE
enable spot price settings for spot nodes

### DIFF
--- a/odc_eks/modules/eks/worker_image.tf
+++ b/odc_eks/modules/eks/worker_image.tf
@@ -87,6 +87,9 @@ resource "aws_launch_template" "spot" {
 
   instance_market_options {
     market_type = "spot"
+    spot_options {
+      max_price = var.max_spot_price
+    }
   }
 
   network_interfaces {


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- There is a param `max_spot_price` but never been used to set spot max price. This PR will solve this issue #214.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- update spot node launch template. require to execute roll instance script to apply this change.
