### PR TITLE
aws_auth enhancement - accepts user_config_template and role_config_template param

### DIFF
--- a/odc_k8s/aws_auth.tf
+++ b/odc_k8s/aws_auth.tf
@@ -1,3 +1,11 @@
+locals {
+  deafult_user_configmap_template = length(var.users) > 0 ? data.template_file.map_user_config.rendered : null
+  mapUser = var.user_config_template != "" ? var.user_config_template : local.deafult_user_configmap_template
+
+  deafult_role_config_template = length(var.node_roles) > 0 ? data.template_file.map_role_config.rendered : null
+  mapRole = var.role_config_template != "" ? var.role_config_template : local.deafult_role_config_template
+}
+
 data "template_file" "map_user_config" {
   template = <<EOF
 %{ for user_name, user_arn in var.users ~}
@@ -34,8 +42,8 @@ resource "kubernetes_config_map" "aws_auth" {
   }
 
   data = {
-    mapRoles = data.template_file.map_role_config.rendered
-    mapUsers = (length(var.users) > 0) ? data.template_file.map_user_config.rendered : null
+    mapRoles = local.mapRole
+    mapUsers = local.mapUser
   }
 
 }

--- a/odc_k8s/aws_auth.tf
+++ b/odc_k8s/aws_auth.tf
@@ -1,9 +1,9 @@
 locals {
-  deafult_user_configmap_template = length(var.users) > 0 ? data.template_file.map_user_config.rendered : null
-  mapUser = var.user_config_template != "" ? var.user_config_template : local.deafult_user_configmap_template
+  default_user_configmap_template = length(var.users) > 0 ? data.template_file.map_user_config.rendered : null
+  mapUsers = var.user_config_template != "" ? var.user_config_template : local.default_user_configmap_template
 
-  deafult_role_config_template = length(var.node_roles) > 0 ? data.template_file.map_role_config.rendered : null
-  mapRole = var.role_config_template != "" ? var.role_config_template : local.deafult_role_config_template
+  default_user_configmap_template = length(var.node_roles) > 0 ? data.template_file.map_role_config.rendered : null
+  mapRoles = var.role_config_template != "" ? var.role_config_template : local.default_user_configmap_template
 }
 
 data "template_file" "map_user_config" {
@@ -42,8 +42,8 @@ resource "kubernetes_config_map" "aws_auth" {
   }
 
   data = {
-    mapRoles = local.mapRole
-    mapUsers = local.mapUser
+    mapRoles = local.mapRoles
+    mapUsers = local.mapUsers
   }
 
 }

--- a/odc_k8s/variables.tf
+++ b/odc_k8s/variables.tf
@@ -44,13 +44,13 @@ variable "users" {
 variable "role_config_template" {
   default = ""
   type = string
-  description = "aws-auth role config template"
+  description = "aws-auth MapRoles config template"
 }
 
 variable "user_config_template" {
   default = ""
   type = string
-  description = "aws-auth user config template"
+  description = "aws-auth MapUsers config template"
 }
 
 variable "db_hostname" {

--- a/odc_k8s/variables.tf
+++ b/odc_k8s/variables.tf
@@ -24,6 +24,7 @@ variable "cluster_id" {
 }
 
 variable "node_roles" {
+  default = {}
   type = map
   description = "A list of node roles that will be given access to the cluster"
 }
@@ -38,6 +39,18 @@ variable "users" {
   default = {}
   type = map
   description = "A list of users that will be given access to the cluster"
+}
+
+variable "role_config_template" {
+  default = ""
+  type = string
+  description = "aws-auth role config template"
+}
+
+variable "user_config_template" {
+  default = ""
+  type = string
+  description = "aws-auth user config template"
 }
 
 variable "db_hostname" {


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

aws_auth enhancement - accepts user_config_template and role_config_template optional parameters. This will allow us to override  aws-auth `mapRoles` and `mapUsers` settings (rather than default config - set as part of `aws_auth.tf` tf template). 

Benefit - 
- more flexibility in setting `aws-auth` 
- manage user access with different permission to cluster become easy and manage in your live repo like -

```
data "template_file" "map_user_config" {
  template = <<EOF
%{ for user_name, user_arn in local.admin_users ~}
- userarn: ${user_arn}
  username: ${user_name}
  groups:
    - system:masters
%{ endfor ~}
%{ for user_name, user_arn in local.web_users ~}
- userarn: ${user_arn}
  username: ${user_name}
  groups:
    - web-user-group
%{ endfor ~}
EOF
}

module "odc_k8s" {
  source = "github.com/opendatacube/datacube-k8s-eks//odc_k8s?ref=master
  ...
  user_config_template = data.template_file.map_user_config.rendered
  ...
}
```
- For reference, see the example how to manage user access [here](https://www.agilepartner.net/en/adding-users-to-your-eks-cluster/)

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No impact to existing `aws-auth` setup.