### PR TITLE
Backend init s3 policy

### DIFF
--- a/examples/backend_init/terraform-backend.tf
+++ b/examples/backend_init/terraform-backend.tf
@@ -39,6 +39,15 @@ resource "aws_s3_bucket" "terraform-state-storage-s3" {
   tags = module.odc_backend_label.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "terraform-state-storage-s3" {
+  bucket = aws_s3_bucket.terraform-state-storage-s3.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # The terraform lock database resource
 resource "aws_dynamodb_table" "terraform_state_lock" {
   name           = "${module.odc_backend_label.id}-terraform-lock"

--- a/odc_eks/modules/eks/workers.tf
+++ b/odc_eks/modules/eks/workers.tf
@@ -23,23 +23,8 @@ resource "aws_autoscaling_group" "nodes" {
       propagate_at_launch = true
     },
     {
-      key                 = "owner"
-      value               = var.owner
-      propagate_at_launch = true
-    },
-    {
-      key                 = "namespace"
-      value               = var.namespace
-      propagate_at_launch = true
-    },
-    {
       key                 = "environment"
       value               = var.environment
-      propagate_at_launch = true
-    },
-    {
-      key                 = "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"
-      value               = "owned"
       propagate_at_launch = true
     },
     {
@@ -55,6 +40,21 @@ resource "aws_autoscaling_group" "nodes" {
     {
       key                 = "k8s.io/cluster-autoscaler/node-template/label/nodetype"
       value               = "ondemand"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "namespace"
+      value               = var.namespace
+      propagate_at_launch = true
+    },
+    {
+      key                 = "owner"
+      value               = var.owner
       propagate_at_launch = true
     },
   ]
@@ -91,23 +91,8 @@ resource "aws_autoscaling_group" "spot_nodes" {
       propagate_at_launch = true
     },
     {
-      key                 = "owner"
-      value               = var.owner
-      propagate_at_launch = true
-    },
-    {
-      key                 = "namespace"
-      value               = var.namespace
-      propagate_at_launch = true
-    },
-    {
       key                 = "environment"
       value               = var.environment
-      propagate_at_launch = true
-    },
-    {
-      key                 = "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"
-      value               = "owned"
       propagate_at_launch = true
     },
     {
@@ -123,6 +108,21 @@ resource "aws_autoscaling_group" "spot_nodes" {
     {
       key                 = "k8s.io/cluster-autoscaler/node-template/label/nodetype"
       value               = "spot"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "namespace"
+      value               = var.namespace
+      propagate_at_launch = true
+    },
+    {
+      key                 = "owner"
+      value               = var.owner
       propagate_at_launch = true
     },
   ]


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Updated backend_init example module - added `aws_s3_bucket_public_access_block` resource to config s3 public access block to solve #227 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No impact