### PR TITLE
Issue 226 cognito

### DIFF
--- a/cognito/README.md
+++ b/cognito/README.md
@@ -32,21 +32,18 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
     auto_verify = true
     user_pool_name       = "odc-stage-cluster-userpool"
     user_pool_domain     = "odc-stage-cluster-auth"
-    user_groups = [
-      {
-        name        = "dev-group"
-        description = "Group defines Jupyterhub dev users"
-        precedence  = 5
+    user_groups = {
+      "dev-group" = {
+        "description" = "Group defines Jupyterhub dev users"
+        "precedence"  = 5
       },
-      {
-        name        = "default-group"
-        description = "Group defines Jupyterhub default users"
-        precedence  = 10
+      "default-group" = {
+        "description" = "Group defines Jupyterhub default users"
+        "precedence"  = 10
       }
-    ]
-    app_clients = [
-      {
-        name          = "jupyterhub-client"
+    }
+    app_clients = {
+      "jupyterhub-client" = {
         callback_urls = [
           "https://app.jupyterhub.example.com/oauth_callback",
           "https://app.jupyterhub.example.com"
@@ -57,7 +54,7 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
         default_redirect_uri = "app.jupyterhub.example.com"
         explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_CUSTOM_AUTH"]
       }
-    ]
+    }
     
     # Default tags + resource labels
     owner           = "odc-owner"
@@ -81,23 +78,19 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | owner | The owner of the environment | string |  | yes |
 | namespace | The unique namespace for the environment, which could be your organization name or abbreviation, e.g. 'odc' | string |  | yes |
 | environment | The name of the environment - e.g. dev, stage | string |  | yes |
-| auto_verify | Set to true to allow the user account to be auto verified. False - admin will need to verify | bool | | yes |
-| callback_url | **Deprecated Var** - The callback url for your application | list(string) | | no |
-| callback_urls | **Deprecated Var** - List of allowed callback URLs for the identity providers | list(string) | | yes |
-| default_redirect_uri | **Deprecated Var** - The default redirect URI. Must be in the list of callback URLs | string | | no |
-| logout_urls | **Deprecated Var** - List of allowed logout URLs for the identity providers | list(string) | | no |
-| app_clients | List of user pool app clients to support multiple applications | List(object({name = string,callback_urls = list(string),logout_urls = list(string),default_redirect_uri = string,explicit_auth_flows = list(string)})) | [] | no |
-| user_pool_name | The cognito user pool name | string | | yes |
-| user_pool_domain | The cognito user pool domain | string | | yes |
-| user_groups | List of user groups manage by cognito user pool | list(object({name = string,description = string,precedence = number})) | [] | no |
+| app_clients | Map of Cognito user pool app clients | map |  | yes |
 | admin_create_user_config | The configuration for AdminCreateUser requests | map | {} | no |
 | admin_create_user_config_allow_admin_create_user_only | Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app | bool | false | No | 
 | admin_create_user_config_unused_account_validity_days | The user account expiration limit, in days, after which the account is no longer usable | number | 0 | No |
 | admin_create_user_config_email_message | The message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively | string | null | No |
 | admin_create_user_config_email_subject | The subject line for email messages | string | null | No |
+| admin_create_user_config_sms_message | The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively | string | null | No |
+| auto_verify | Set to true to allow the user account to be auto verified. False - admin will need to verify | bool | | yes |
 | email_verification_message | A string representing the email verification message | string | null | No |
 | email_verification_subject | A string representing the email verification subject | string | null | No |
-| admin_create_user_config_sms_message | The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively | string | null | No |
+| user_groups | Cognito user groups | map | {} | no |
+| user_pool_name | Map of Cognito user pool name | string | | yes |
+| user_pool_domain | Cognito user pool domain | string | | yes |
 | tags | Additional tags - e.g. `map('StackName','XYZ')` | map(string) | {} | no |
 
 ### Outputs
@@ -105,7 +98,5 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 |------|-------------|------|
 | userpool_id | Cognito user pool ID | true |
 | userpool_domain | Cognito user pood domain | false |
-| client_id | **Deprecated** Cognito user pool client ID | true |
-| client_secret | **Deprecated** Cognito user pool client secret | true |
-| client_ids | Cognito user pool client IDs | true |
-| client_secrets | Cognito user pool client secrets | true |
+| client_ids | Map of Cognito user pool client IDs | true |
+| client_secrets | Map of Cognito user pool client secrets | true |

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -91,32 +91,17 @@ locals {
   admin_create_user_config = [local.admin_create_user_config_default]
 }
 
-# TODO: remove me! - This resource is deprecated. only kept to support v1.8.0 release.
-resource "aws_cognito_user_pool_client" "client" {
-  count                                = (length(var.app_clients) == 0) ? 1 : 0
-  name                                 = "client"
-  user_pool_id                         = aws_cognito_user_pool.pool.id
-  generate_secret                      = true
-  supported_identity_providers         = ["COGNITO"]
-  callback_urls                        = (var.callback_url != "") ? [var.callback_url] : var.callback_urls
-  default_redirect_uri                 = var.default_redirect_uri
-  logout_urls                          = var.logout_urls
-  allowed_oauth_flows_user_pool_client = true
-  allowed_oauth_scopes                 = ["email", "aws.cognito.signin.user.admin", "openid"]
-  allowed_oauth_flows                  = ["code"]
-}
-
 resource "aws_cognito_user_pool_client" "clients" {
-  count                        = length(var.app_clients)
-  name                         = var.app_clients[count.index].name
+  for_each                     = var.app_clients
+  name                         = each.key
   user_pool_id                 = aws_cognito_user_pool.pool.id
   generate_secret              = true
   supported_identity_providers = ["COGNITO"]
 
-  callback_urls        = var.app_clients[count.index].callback_urls
-  default_redirect_uri = var.app_clients[count.index].default_redirect_uri
-  logout_urls          = var.app_clients[count.index].logout_urls
-  explicit_auth_flows  = var.app_clients[count.index].explicit_auth_flows
+  callback_urls        = each.value.callback_urls
+  default_redirect_uri = each.value.default_redirect_uri
+  logout_urls          = each.value.logout_urls
+  explicit_auth_flows  = each.value.explicit_auth_flows
 
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = ["email", "aws.cognito.signin.user.admin", "openid"]
@@ -129,9 +114,9 @@ resource "aws_cognito_user_pool_domain" "domain" {
 }
 
 resource "aws_cognito_user_group" "group" {
-  count        = length(var.user_groups)
+  for_each     = var.user_groups
   user_pool_id = aws_cognito_user_pool.pool.id
-  name         = var.user_groups[count.index].name
-  description  = var.user_groups[count.index].description
-  precedence   = var.user_groups[count.index].precedence
+  name         = each.key
+  description  = each.value.description
+  precedence   = each.value.precedence
 }

--- a/cognito/output.tf
+++ b/cognito/output.tf
@@ -1,4 +1,3 @@
-
 output "userpool_id" {
   value     = aws_cognito_user_pool.pool.id
   sensitive = true
@@ -8,24 +7,18 @@ output "userpool_domain" {
   value = aws_cognito_user_pool_domain.domain.domain
 }
 
-# TODO: remove me! - This is deprecated.
-output "client_id" {
-  value     = (length(var.app_clients) == 0) ? aws_cognito_user_pool_client.client[0].id : null
-  sensitive = true
-}
-
-# TODO: remove me! - This is deprecated.
-output "client_secret" {
-  value     = (length(var.app_clients) == 0) ? aws_cognito_user_pool_client.client[0].client_secret : null
-  sensitive = true
-}
-
 output "client_ids" {
-  value     = (length(var.app_clients) > 0) ? aws_cognito_user_pool_client.clients.*.id : null
+  value = {
+    for client in aws_cognito_user_pool_client.clients :
+    client.name => client.id
+  }
   sensitive = true
 }
 
 output "client_secrets" {
-  value     = (length(var.app_clients) > 0) ? aws_cognito_user_pool_client.clients.*.client_secret : null
+  value = {
+    for client in aws_cognito_user_pool_client.clients :
+    client.name => client.client_secret
+  }
   sensitive = true
 }

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -1,60 +1,22 @@
-variable "callback_url" {
-  type        = string
-  description = "**Deprecated Var** - The callback url for your application"
-  default     = ""
-}
-
-# TODO: remove me! - This is deprecated. Use `app_clients` var instead.
-variable "callback_urls" {
-  type        = list(string)
-  description = "List of allowed callback URLs for the identity providers"
-  default     = []
-}
-
-# TODO: remove me! - This is deprecated. Use `app_clients` var instead.
-variable "default_redirect_uri" {
-  type        = string
-  description = "The default redirect URI. Must be in the list of callback URLs"
-  default     = ""
-}
-
-# TODO: remove me! - This is deprecated. Use `app_clients` var instead.
-variable "logout_urls" {
-  type        = list(string)
-  description = "List of allowed logout URLs for the identity providers"
-  default     = []
-}
-
 variable "app_clients" {
-  default     = []
-  description = "List of user pool app clients to support multiple applications"
-  type = list(object({
-    name                 = string
-    callback_urls        = list(string)
-    logout_urls          = list(string)
-    default_redirect_uri = string
-    explicit_auth_flows  = list(string)
-  }))
+  description = "Map of Cognito user pool app clients"
+  type        = map
 }
 
 variable "user_pool_name" {
   type        = string
-  description = "The cognito user pool name"
+  description = "Cognito user pool name"
 }
 
 variable "user_pool_domain" {
   type        = string
-  description = "The cognito user pool domain"
+  description = "Cognito user pool domain"
 }
 
 variable "user_groups" {
-  default     = []
-  description = "List of user groups manage by cognito user pool"
-  type = list(object({
-    name        = string
-    description = string
-    precedence  = number
-  }))
+  default     = {}
+  description = "Map of Cognito user groups"
+  type        = map
 }
 
 variable "auto_verify" {

--- a/examples/stage/01_odc_eks/cognito.tf
+++ b/examples/stage/01_odc_eks/cognito.tf
@@ -5,31 +5,26 @@ module "cognito_auth" {
   auto_verify      = true
   user_pool_name   = "${module.odc_cluster_label.id}-userpool"
   user_pool_domain = "${module.odc_cluster_label.id}-auth"
-  user_groups = [
-    {
-      name        = "dev-group"
-      description = "Group defines dev users"
-      precedence  = 5
+  user_groups = {
+    "dev-group" = {
+      "description" = "Group defines dev users"
+      "precedence"  = 5
     },
-    {
-      name        = "internal-group"
-      description = "Group defines internal users"
-      precedence  = 6
+    "internal-group" = {
+      "description" = "Group defines internal users"
+      "precedence"  = 6
     },
-    {
-      name        = "trusted-group"
-      description = "Group defines trusted users"
-      precedence  = 7
+    "trusted-group" = {
+      "description" = "Group defines trusted users"
+      "precedence"  = 7
     },
-    {
-      name        = "default-group"
-      description = "Group defines default users"
-      precedence  = 10
+    "default-group" = {
+      "description" = "Group defines default users"
+      "precedence"  = 10
     }
-  ]
-  app_clients = [
-    {
-      name = "sandbox-client"
+  }
+  app_clients = {
+    "sandbox-client" = {
       callback_urls = [
         "https://${local.sandbox_host_name}/oauth_callback",
         "https://${local.sandbox_host_name}"
@@ -38,9 +33,13 @@ module "cognito_auth" {
         "https://${local.sandbox_host_name}"
       ]
       default_redirect_uri = "https://${local.sandbox_host_name}"
-      explicit_auth_flows  = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_CUSTOM_AUTH"]
+      explicit_auth_flows = [
+        "ALLOW_REFRESH_TOKEN_AUTH",
+        "ALLOW_USER_SRP_AUTH",
+        "ALLOW_CUSTOM_AUTH"
+      ]
     }
-  ]
+  }
 
   # Tags
   owner       = local.owner

--- a/examples/stage/01_odc_eks/outputs.tf
+++ b/examples/stage/01_odc_eks/outputs.tf
@@ -69,21 +69,11 @@ output "cognito_auth_userpool_domain" {
 }
 
 output "cognito_auth_userpool_jhub_client_id" {
-  value     = module.cognito_auth.client_ids[0]
+  value     = module.cognito_auth.client_ids["sandbox-client"]
   sensitive = true
 }
 
 output "cognito_auth_userpool_jhub_client_secret" {
-  value     = module.cognito_auth.client_secrets[0]
-  sensitive = true
-}
-
-output "cognito_auth_userpool_airflow_client_id" {
-  value     = module.cognito_auth.client_ids[1]
-  sensitive = true
-}
-
-output "cognito_auth_userpool_airflow_client_secret" {
-  value     = module.cognito_auth.client_secrets[1]
+  value     = module.cognito_auth.client_secrets["sandbox-client"]
   sensitive = true
 }

--- a/odc_eks/modules/eks/workers.tf
+++ b/odc_eks/modules/eks/workers.tf
@@ -28,13 +28,13 @@ resource "aws_autoscaling_group" "nodes" {
       propagate_at_launch = true
     },
     {
-      key                 = "k8s.io/cluster-autoscaler/enabled"
-      value               = "true"
+      key                 = "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"
+      value               = "owned"
       propagate_at_launch = true
     },
     {
-      key                 = "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"
-      value               = "owned"
+      key                 = "k8s.io/cluster-autoscaler/enabled"
+      value               = "true"
       propagate_at_launch = true
     },
     {
@@ -96,13 +96,13 @@ resource "aws_autoscaling_group" "spot_nodes" {
       propagate_at_launch = true
     },
     {
-      key                 = "k8s.io/cluster-autoscaler/enabled"
-      value               = "true"
+      key                 = "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"
+      value               = "owned"
       propagate_at_launch = true
     },
     {
-      key                 = "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"
-      value               = "owned"
+      key                 = "k8s.io/cluster-autoscaler/enabled"
+      value               = "true"
       propagate_at_launch = true
     },
     {


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- `cognito` module currently uses count to loop through `app_clients` and `user_groups` variable to provision resources. By doing this we need to remember the order of the resource - This is fragile. This PR enhance `cognito` module to solve issue #226 and #210 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- Yes. If you are migrating from odc terraform version `v1.8.0`, then you are require to change cognito.tf configuration as per README.  e.g. -
```
  module "cognito_auth" {
    source = "github.com/opendatacube/datacube-k8s-eks//cognito?ref=master"
    
    auto_verify = true
    user_pool_name       = "odc-stage-cluster-userpool"
    user_pool_domain     = "odc-stage-cluster-auth"
    user_groups = {
      "dev-group" = {
        "description" = "Group defines Jupyterhub dev users"
        "precedence"  = 5
      },
      "default-group" = {
        "description" = "Group defines Jupyterhub default users"
        "precedence"  = 10
      }
    }
    app_clients = {
      "jupyterhub-client" = {
        callback_urls = [
          "https://app.jupyterhub.example.com/oauth_callback",
          "https://app.jupyterhub.example.com"
        ]
        logout_urls   = [
          "https://app.jupyterhub.example.com"
        ]
        default_redirect_uri = "app.jupyterhub.example.com"
        explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_CUSTOM_AUTH"]
      }
    }
    
    # Default tags + resource labels
    owner           = "odc-owner"
    namespace       = "odc"
    environment     = "stage"
  }

  output "cognito_auth_userpool_jhub_client_id" {
    value     = module.cognito_auth.client_ids["sandbox-client"]
    sensitive = true
  }

  output "cognito_auth_userpool_jhub_client_secret" {
    value     = module.cognito_auth.client_secrets["sandbox-client"]
    sensitive = true
  }
```
- Also this will recreates cognito user pool `app-clients` and `user-groups` so if you don't wont it then migrate terraform state as explained below -
```
**step 1:** Download `odc_eks` module latest state file - just for sanity

**step 2:** Move cognito states using terraform state mv command for all the resources for - `aws_cognito_user_group` and `aws_cognito_user_pool_client`(optional)
e.g.
 terraform state mv 'module.cognito_auth.aws_cognito_user_pool_client.clients[0]' 'module.cognito_auth.aws_cognito_user_pool_client.clients["sandbox-client"]'

terraform state mv 'module.cognito_auth.aws_cognito_user_group.group[0]' 'module.cognito_auth.aws_cognito_user_group.group["dev-group"]'

**step 3:** Execute terraform state plant to validate changes
```