### PR TITLE
cognito module - support for region

### DIFF
--- a/cognito/README.md
+++ b/cognito/README.md
@@ -29,9 +29,11 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
   module "cognito_auth" {
     source = "github.com/opendatacube/datacube-k8s-eks//cognito?ref=master"
     
-    auto_verify = true
-    user_pool_name       = "odc-stage-cluster-userpool"
-    user_pool_domain     = "odc-stage-cluster-auth"
+    region = "ap-southeast-2"
+
+    auto_verify       = true
+    user_pool_name    = "odc-stage-cluster-userpool"
+    user_pool_domain  = "odc-stage-cluster-auth"
     user_groups = {
       "dev-group" = {
         "description" = "Group defines Jupyterhub dev users"
@@ -78,6 +80,7 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | owner | The owner of the environment | string |  | yes |
 | namespace | The unique namespace for the environment, which could be your organization name or abbreviation, e.g. 'odc' | string |  | yes |
 | environment | The name of the environment - e.g. dev, stage | string |  | yes |
+| region | The AWS region to provision cognito resources | string | "ap-southeast-2" | no |
 | app_clients | Map of Cognito user pool app clients | map |  | yes |
 | admin_create_user_config | The configuration for AdminCreateUser requests | map | {} | no |
 | admin_create_user_config_allow_admin_create_user_only | Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app | bool | false | No | 

--- a/cognito/provider.tf
+++ b/cognito/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region      = var.region
+  max_retries = 10
+}
+

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -42,6 +42,12 @@ variable "environment" {
   description = "The name of the environment - e.g. dev, stage, prod"
 }
 
+variable "region" {
+  description = "The AWS region to provision cognito resources"
+  type        = string
+  default     = "ap-southeast-2"
+}
+
 # admin_create_user_config
 variable "admin_create_user_config" {
   description = "The configuration for AdminCreateUser requests"


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- This will solve issue - #232.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- default value for `region` is set to `ap-southeast-2`. so all the resources created by this module in this region only. Please provide value for `region` attribute if that is not the case.