### PR TITLE
remove provider from cognito module as rob suggested

### DIFF
--- a/cognito/README.md
+++ b/cognito/README.md
@@ -26,8 +26,19 @@ The complete Open Data Cube terraform AWS example is provided for kick start [he
 Copy the example to create your own live repo to setup ODC infrastructure to run [jupyterhub](https://github.com/jupyterhub/zero-to-jupyterhub-k8s) notebook and ODC web services to your own AWS account.
 
 ```hcl-terraform
+  provider "aws" {
+    alias       = "usw2"
+    region      = "us-west-2"
+    max_retries = 10
+  }
+
   module "cognito_auth" {
     source = "github.com/opendatacube/datacube-k8s-eks//cognito?ref=master"
+  
+    # Optional configuration require if you want to override the default provider
+    providers = {
+      aws = aws.usw2
+    }
 
     auto_verify       = true
     user_pool_name    = "odc-stage-cluster-userpool"

--- a/cognito/README.md
+++ b/cognito/README.md
@@ -28,8 +28,6 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 ```hcl-terraform
   module "cognito_auth" {
     source = "github.com/opendatacube/datacube-k8s-eks//cognito?ref=master"
-    
-    region = "ap-southeast-2"
 
     auto_verify       = true
     user_pool_name    = "odc-stage-cluster-userpool"
@@ -80,7 +78,6 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | owner | The owner of the environment | string |  | yes |
 | namespace | The unique namespace for the environment, which could be your organization name or abbreviation, e.g. 'odc' | string |  | yes |
 | environment | The name of the environment - e.g. dev, stage | string |  | yes |
-| region | The AWS region to provision cognito resources | string | "ap-southeast-2" | no |
 | app_clients | Map of Cognito user pool app clients | map |  | yes |
 | admin_create_user_config | The configuration for AdminCreateUser requests | map | {} | no |
 | admin_create_user_config_allow_admin_create_user_only | Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app | bool | false | No | 

--- a/cognito/provider.tf
+++ b/cognito/provider.tf
@@ -1,5 +1,0 @@
-provider "aws" {
-  region      = var.region
-  max_retries = 10
-}
-

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -42,12 +42,6 @@ variable "environment" {
   description = "The name of the environment - e.g. dev, stage, prod"
 }
 
-variable "region" {
-  description = "The AWS region to provision cognito resources"
-  type        = string
-  default     = "ap-southeast-2"
-}
-
 # admin_create_user_config
 variable "admin_create_user_config" {
   description = "The configuration for AdminCreateUser requests"


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- Remove region and provider from cognito module instead will manage provider from root module as suggested in issue #235. 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- Thanks @woodcockr 