### PR TITLE
updated AWS SSM manage role

### DIFF
--- a/odc_eks/modules/eks/worker_policy.tf
+++ b/odc_eks/modules/eks/worker_policy.tf
@@ -71,7 +71,7 @@ resource "aws_iam_role_policy_attachment" "eks_node_AmazonEC2ContainerRegistryRe
 
 resource "aws_iam_role_policy_attachment" "eks_node_AmazonEC2RoleforSSM" {
   count      = var.enable_ec2_ssm ? 1 : 0
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
   role       = aws_iam_role.eks_node.name
 }
 


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- AWS SSM managed role `AmazonEC2RoleforSSM` will will soon be deprecated. so changed it to use new role instead.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- solve #237. No impact.
