### PR TITLE
Allow flux to support registry exclude image option

### DIFF
--- a/odc_eks/modules/eks/worker_policy.tf
+++ b/odc_eks/modules/eks/worker_policy.tf
@@ -72,7 +72,6 @@ resource "aws_iam_role_policy_attachment" "eks_node_AmazonEC2ContainerRegistryRe
 resource "aws_iam_role_policy_attachment" "eks_node_AmazonEC2RoleforSSM" {
   count      = var.enable_ec2_ssm ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-
   role       = aws_iam_role.eks_node.name
 }
 

--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -160,6 +160,7 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | flux_git_path | Relative path inside specified git repository to search for manifest files | string | "" | No | 
 | flux_git_label | Label prefix that is used to track flux syncing inside the git repository | string | "flux-sync" | No | 
 | flux_additional_args | Use additional arg for connect flux to fluxcloud. Syntext: --connect=ws://fluxcloud | string | "" | No | 
+| flux_registry_exclude_images | comma separated string lists of registry images to exclud from flux auto release: docker.io/*,index.docker.io/* | string | "" | No | 
 | flux_helm_operator_version | Flux helm-operator release version | string | "1.0.1" | No | 
 | enabled_helm_versions | Helm options to support release versions. Valid values: `"v2"`/`"v3"`/`"v2\\,v3"` | string | "v2\\,v3" | No | 
 

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -9,6 +9,10 @@ git:
   pollInterval: 1m
 registry:
   pollInterval: 1m
+  %{ if registry_exclude_images != "" }
+  excludeImages:
+    - ${registry_exclude_images}
+  - ${endif}
 %{ if additional_args != "" }
 additionalArgs:
   - ${additional_args}

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -10,9 +10,8 @@ git:
 registry:
   pollInterval: 1m
   %{ if registry_exclude_images != "" }
-  excludeImages:
-    - ${registry_exclude_images}
-  - ${endif}
+  excludeImage: ${registry_exclude_images}
+  %{ endif }
 %{ if additional_args != "" }
 additionalArgs:
   - ${additional_args}

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -39,6 +39,12 @@ variable "flux_additional_args" {
   default     = ""
 }
 
+variable "flux_registry_exclude_images" {
+  type        = string
+  description = "comma separated string lists of registry images to exclud from flux auto release"
+  default     = ""
+}
+
 resource "kubernetes_namespace" "flux" {
   count = var.flux_enabled ? 1 : 0
 
@@ -54,11 +60,12 @@ resource "kubernetes_namespace" "flux" {
 data "template_file" "flux_config" {
   template = file("${path.module}/config/flux.yaml")
   vars = {
-    git_repo_url    = var.flux_git_repo_url
-    git_branch      = var.flux_git_branch
-    git_path        = var.flux_git_path
-    git_label       = var.cluster_id
-    additional_args = var.flux_additional_args
+    git_repo_url            = var.flux_git_repo_url
+    git_branch              = var.flux_git_branch
+    git_path                = var.flux_git_path
+    git_label               = var.cluster_id
+    additional_args         = var.flux_additional_args
+    registry_exclude_images = var.flux_registry_exclude_images
   }
 }
 


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- flux chokes on unavailable image from registry (mainly external images where we don't have control) and flooding logs so added optional variable `flux_registry_exclude_images` to instruct Flux to exclude these images from auto-release

> ts=2020-07-08T06:30:58.891563087Z caller=repocachemanager.go:223 component=warmer canonical_name=index.docker.io/cilium/cilium auth={map[]} warn="manifest for tag svc-v2-fix-1.5.0 missing in repository docker.io/cilium/cilium" impact="flux will fail to auto-release workloads with matching images, ask the repository administrator to fix the inconsistency"

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- No impact. Default value is set for variable. Tested.