### PR TITLE
Fluxcd ecr support

### DIFF
--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -130,9 +130,9 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
     fluxcloud_github_url = "https://github.com/opendatacube/flux-odc-sample"
     fluxcloud_commit_template = "{{ .VCSLink }}/commits/{{ .Commit }}"
     flux_registry_ecr = {
-      region    = ""             # Restrict ECR scanning to these AWS regions
-      includeId = ""             # Restrict ECR scanning to these AWS account IDs
-      excludeId = "602401143452" # EKS system account
+      regions    = []               # Restrict ECR scanning to these AWS regions
+      includeIds = []               # Restrict ECR scanning to these AWS account IDs
+      excludeIds = ["602401143452"] # Restrict ECR scanning to exclude these AWS account IDs. Default resticted to EKS system account
     }
     
     # Cloudwatch Log Group - for fluentd
@@ -174,7 +174,7 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | flux_additional_args | Use additional arg for connect flux to fluxcloud. Syntext: --connect=ws://fluxcloud | string | "" | No | 
 | flux_registry_exclude_images | comma separated string lists of registry images to exclud from flux auto release: docker.io/*,index.docker.io/* | string | "" | No | 
 | flux_helm_operator_version | Flux helm-operator release version | string | "1.0.1" | No | 
-| flux_registry_ecr | Use flux_registry_ecr for fluxcd ecr configuration | object({region=string includeId=string excludeId=string}) | { region="" includeId="" excludeId="602401143452" } | No | 
+| flux_registry_ecr | Use flux_registry_ecr for fluxcd ecr configuration | object({regions=list(string) includeIds=list(string) excludeId=list(string)}) | { region="" includeId="" excludeId="602401143452" } | No | 
 | flux_service_account_arn | provide flux OIDC service account role arn | "" | No | 
 | enabled_helm_versions | Helm options to support release versions. Valid values: `"v2"`/`"v3"`/`"v2\\,v3"` | string | "v2\\,v3" | No | 
 

--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -67,6 +67,13 @@ users = {
 user_config_template = "<renderd aws-auth MaapUsers config template>"
 ```
 
+### IAM roles for Kubernetes service accounts
+With the introduction of IAM roles for services accounts (IRSA), you can create an IAM role specific to your workload’s requirement in Kubernetes.
+This also enables the security principle of least privilege by creating fine grained roles at a pod level instead of node level.
+The IAM roles for service accounts feature is available on new Amazon EKS Kubernetes version 1.14 and later clusters.
+For more detail read - [Introducing fine-grained IAM roles for service accounts](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/)
+
+
 ## Usage
 
 The complete Open Data Cube terraform AWS example is provided for kick start [here](https://github.com/opendatacube/datacube-k8s-eks/tree/master/examples/stage).

--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -122,6 +122,11 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
     fluxcloud_slack_emoji = ":zoidberg:"
     fluxcloud_github_url = "https://github.com/opendatacube/flux-odc-sample"
     fluxcloud_commit_template = "{{ .VCSLink }}/commits/{{ .Commit }}"
+    flux_registry_ecr = {
+      region    = ""             # Restrict ECR scanning to these AWS regions
+      includeId = ""             # Restrict ECR scanning to these AWS account IDs
+      excludeId = "602401143452" # EKS system account
+    }
     
     # Cloudwatch Log Group - for fluentd
     cloudwatch_logs_enabled  = true
@@ -162,6 +167,7 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | flux_additional_args | Use additional arg for connect flux to fluxcloud. Syntext: --connect=ws://fluxcloud | string | "" | No | 
 | flux_registry_exclude_images | comma separated string lists of registry images to exclud from flux auto release: docker.io/*,index.docker.io/* | string | "" | No | 
 | flux_helm_operator_version | Flux helm-operator release version | string | "1.0.1" | No | 
+| flux_registry_ecr |Use flux_registry_ecr for fluxcd ecr configuration | object({region=string includeId=string excludeId=string}) | { region="" includeId="" excludeId="602401143452" } | No | 
 | enabled_helm_versions | Helm options to support release versions. Valid values: `"v2"`/`"v3"`/`"v2\\,v3"` | string | "v2\\,v3" | No | 
 
 ### Inputs - FluxCloud

--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -174,7 +174,7 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | flux_additional_args | Use additional arg for connect flux to fluxcloud. Syntext: --connect=ws://fluxcloud | string | "" | No | 
 | flux_registry_exclude_images | comma separated string lists of registry images to exclud from flux auto release: docker.io/*,index.docker.io/* | string | "" | No | 
 | flux_helm_operator_version | Flux helm-operator release version | string | "1.0.1" | No | 
-| flux_registry_ecr | Use flux_registry_ecr for fluxcd ecr configuration | object({regions=list(string) includeIds=list(string) excludeId=list(string)}) | { region="" includeId="" excludeId="602401143452" } | No | 
+| flux_registry_ecr | Use flux_registry_ecr for fluxcd ecr configuration | object({regions=list(string) includeIds=list(string) excludeIds=list(string)}) | { regions=[] includeIds=[] excludeIds=["602401143452"] } | No | 
 | flux_service_account_arn | provide flux OIDC service account role arn | "" | No | 
 | enabled_helm_versions | Helm options to support release versions. Valid values: `"v2"`/`"v3"`/`"v2\\,v3"` | string | "v2\\,v3" | No | 
 

--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -167,7 +167,8 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
 | flux_additional_args | Use additional arg for connect flux to fluxcloud. Syntext: --connect=ws://fluxcloud | string | "" | No | 
 | flux_registry_exclude_images | comma separated string lists of registry images to exclud from flux auto release: docker.io/*,index.docker.io/* | string | "" | No | 
 | flux_helm_operator_version | Flux helm-operator release version | string | "1.0.1" | No | 
-| flux_registry_ecr |Use flux_registry_ecr for fluxcd ecr configuration | object({region=string includeId=string excludeId=string}) | { region="" includeId="" excludeId="602401143452" } | No | 
+| flux_registry_ecr | Use flux_registry_ecr for fluxcd ecr configuration | object({region=string includeId=string excludeId=string}) | { region="" includeId="" excludeId="602401143452" } | No | 
+| flux_service_account_arn | provide flux OIDC service account role arn | "" | No | 
 | enabled_helm_versions | Helm options to support release versions. Valid values: `"v2"`/`"v3"`/`"v2\\,v3"` | string | "v2\\,v3" | No | 
 
 ### Inputs - FluxCloud

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -9,11 +9,11 @@ git:
   pollInterval: 1m
 registry:
   pollInterval: 1m
-  %{ if flux_registry_ecr.includeId != "" }
+  %{ if length(flux_registry_ecr.includeIds) > 0 }
   ecr:
-    region: "${flux_registry_ecr.region}"
-    includeId: "${flux_registry_ecr.includeId}"
-    excludeId: "${flux_registry_ecr.excludeId}"
+    region: "${join(",", flux_registry_ecr.regions)}"
+    includeId: "${join(",", flux_registry_ecr.includeIds)}"
+    excludeId: "${join(",", flux_registry_ecr.excludeIds)}"
   %{ endif }
   %{ if registry_exclude_images != "" }
   excludeImage: ${registry_exclude_images}

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -1,3 +1,9 @@
+rbac:
+  create: true
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "${service_account_arn}"
 helmOperator:
   create: true
   createCRD: false

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -1,9 +1,3 @@
-rbac:
-  create: true
-serviceAccount:
-  create: true
-  annotations:
-    eks.amazonaws.com/role-arn: "${service_account_arn}"
 helmOperator:
   create: true
   createCRD: false
@@ -17,9 +11,9 @@ registry:
   pollInterval: 1m
   %{ if flux_registry_ecr.includeId != "" }
   ecr:
-    region: ${flux_registry_ecr.region}
-    includeId: ${flux_registry_ecr.includeId}
-    excludeId: ${flux_registry_ecr.excludeId}
+    region: "${flux_registry_ecr.region}"
+    includeId: "${flux_registry_ecr.includeId}"
+    excludeId: "${flux_registry_ecr.excludeId}"
   %{ endif }
   %{ if registry_exclude_images != "" }
   excludeImage: ${registry_exclude_images}
@@ -30,3 +24,11 @@ additionalArgs:
 %{ endif }
 image:
   repository: fluxcd/flux
+%{ if service_account_arn != "" }
+rbac:
+  create: true
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "${service_account_arn}"
+%{ endif }

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -9,6 +9,12 @@ git:
   pollInterval: 1m
 registry:
   pollInterval: 1m
+  %{ if flux_registry_ecr.includeId != "" }
+  ecr:
+    region: ${flux_registry_ecr.region}
+    includeId: ${flux_registry_ecr.includeId}
+    excludeId: ${flux_registry_ecr.excludeId}
+  %{ endif }
   %{ if registry_exclude_images != "" }
   excludeImage: ${registry_exclude_images}
   %{ endif }

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -45,6 +45,12 @@ variable "flux_registry_exclude_images" {
   default     = ""
 }
 
+variable "flux_service_account_arn" {
+  type        = string
+  description = "provide flux OIDC service account role arn"
+  default     = ""
+}
+
 variable "flux_registry_ecr" {
   description = "Use flux_registry_ecr for fluxcd ecr configuration"
   type = object({
@@ -88,6 +94,7 @@ resource "helm_release" "flux" {
       additional_args         = var.flux_additional_args
       registry_exclude_images = var.flux_registry_exclude_images
       flux_registry_ecr       = var.flux_registry_ecr
+      service_account_arn     = var.flux_service_account_arn
     })
   ]
 }

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -41,8 +41,22 @@ variable "flux_additional_args" {
 
 variable "flux_registry_exclude_images" {
   type        = string
-  description = "comma separated string lists of registry images to exclud from flux auto release"
+  description = "comma separated string lists of registry images to exclude from flux auto release"
   default     = ""
+}
+
+variable "flux_registry_ecr" {
+  description = "Use flux_registry_ecr for fluxcd ecr configuration"
+  type = object({
+    region    = string
+    includeId = string
+    excludeId = string
+  })
+  default = {
+    region    = ""             # Restrict ECR scanning to these AWS regions
+    includeId = ""             # Restrict ECR scanning to these AWS account IDs
+    excludeId = "602401143452" # EKS system account
+  }
 }
 
 resource "kubernetes_namespace" "flux" {
@@ -57,18 +71,6 @@ resource "kubernetes_namespace" "flux" {
   }
 }
 
-data "template_file" "flux_config" {
-  template = file("${path.module}/config/flux.yaml")
-  vars = {
-    git_repo_url            = var.flux_git_repo_url
-    git_branch              = var.flux_git_branch
-    git_path                = var.flux_git_path
-    git_label               = var.cluster_id
-    additional_args         = var.flux_additional_args
-    registry_exclude_images = var.flux_registry_exclude_images
-  }
-}
-
 resource "helm_release" "flux" {
   count      = var.flux_enabled ? 1 : 0
   name       = "flux"
@@ -78,6 +80,14 @@ resource "helm_release" "flux" {
   namespace  = kubernetes_namespace.flux[0].metadata[0].name
 
   values = [
-    data.template_file.flux_config.rendered
+    templatefile("${path.module}/config/flux.yaml", {
+      git_repo_url            = var.flux_git_repo_url
+      git_branch              = var.flux_git_branch
+      git_path                = var.flux_git_path
+      git_label               = var.cluster_id
+      additional_args         = var.flux_additional_args
+      registry_exclude_images = var.flux_registry_exclude_images
+      flux_registry_ecr       = var.flux_registry_ecr
+    })
   ]
 }

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -54,14 +54,14 @@ variable "flux_service_account_arn" {
 variable "flux_registry_ecr" {
   description = "Use flux_registry_ecr for fluxcd ecr configuration"
   type = object({
-    region    = string
-    includeId = string
-    excludeId = string
+    regions    = list(string)
+    includeIds = list(string)
+    excludeIds = list(string)
   })
   default = {
-    region    = ""             # Restrict ECR scanning to these AWS regions
-    includeId = ""             # Restrict ECR scanning to these AWS account IDs
-    excludeId = "602401143452" # EKS system account
+    regions    = []               # Restrict ECR scanning to these AWS regions
+    includeIds = []               # Restrict ECR scanning to these AWS account IDs
+    excludeIds = ["602401143452"] # Restrict ECR scanning to exclude these AWS account IDs. Default resticted to EKS system account
   }
 }
 


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- Update flux configuration yaml file - optional configuration for rbac + service account role + ecr. This will allow flux to monitor ECR private repositories

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- No impact.
