### PR TITLE
Cape town region support for EKS

### DIFF
--- a/odc_eks/modules/eks/worker_image.tf
+++ b/odc_eks/modules/eks/worker_image.tf
@@ -5,7 +5,7 @@ data "aws_ami" "eks_worker" {
   }
 
   most_recent = true
-  owners      = ["602401143452"] # Amazon EKS AMI Account ID
+  owners      = ["602401143452", "877085696533"] # Amazon EKS AMI Account ID
 }
 
 # EKS currently documents this required userdata for EKS worker nodes to

--- a/odc_k8s/flux_helm_operator.tf
+++ b/odc_k8s/flux_helm_operator.tf
@@ -1,5 +1,5 @@
 variable "flux_helm_operator_version" {
-  default = "1.0.1"
+  default = "1.2.0"
 }
 
 variable "enabled_helm_versions" {


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add
- Added Amazon EKS account support for Cape town region - "877085696533"
- Upgraded fluxcd helm-operator version to `1.2.0` 

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here
- It will rollout new pods for fluxcd helm-operator