### PR TITLE
reapply helm operator crd on helm version update

### DIFF
--- a/odc_k8s/flux_helm_operator.tf
+++ b/odc_k8s/flux_helm_operator.tf
@@ -35,6 +35,8 @@ resource "null_resource" "apply_flux_helm_operator_crd" {
     cluster_updated              = var.cluster_id
     kubernetes_namespace_updated = kubernetes_namespace.flux[0].metadata[0].name
 
+    flux_helm_operator_version_updated = var.flux_helm_operator_version
+
     # Special trigger: When using null_resource, you can use the triggers map both to signal when the provisioners
     # need to re-run (the usual purpose as above) and to retain values you can access via self during the destroy phase.
     # This avoids dependency issues during the destory phase


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

- Re apply helm operator crd on helm version update. Fluxcd helm-operator version upgrade also require update to helm CRD otherwise it breaks the deployment and constantly try to apply hr upgrade in a loop. This PR will fix this.
- Required it for helm upgrade from 1.0.2 -> 1.2.0.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

- apply CRD on helm version upgrade.
