### PR TITLE
Make cf aws provider a proxy

### DIFF
--- a/odc_eks/cloudfront_distribution.tf
+++ b/odc_eks/cloudfront_distribution.tf
@@ -82,7 +82,7 @@ provider "aws" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  provider                  = aws.us
+  provider                  = aws.us-east-1
   count                     = (var.cf_certificate_create && var.cf_enable) ? 1 : 0
   domain_name               = "${var.cf_dns_record}.${local.cf_acm_domains[0]}"
   subject_alternative_names = slice(local.cf_acm_domains, 1, length(local.cf_acm_domains))
@@ -110,7 +110,7 @@ resource "aws_route53_record" "cert_validation" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  provider                = aws.us
+  provider                = aws.us-east-1
   count                   = (var.cf_certificate_create && var.cf_enable) ? 1 : 0
   certificate_arn         = aws_acm_certificate.cert[0].arn
   validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn

--- a/odc_eks/cloudfront_distribution.tf
+++ b/odc_eks/cloudfront_distribution.tf
@@ -78,8 +78,7 @@ variable "cf_price_class" {
 
 # Create a new certificate, this must be in us-east-1 to work with cloudfront
 provider "aws" {
-  region = "us-east-1"
-  alias  = "us"
+  alias  = "us-east-1"
 }
 
 resource "aws_acm_certificate" "cert" {


### PR DESCRIPTION


# Why this change is needed

the odc_eks/cloud_front_distribution.tf currently declares a aws provider for region us-east-1 as this is required for cloudfront. Unfortunately the explicitly declared module provider means you can't specify AWS credentials for the provider to use from the caller. 

The correct approach is to use a Module Provider Alias in the module and then have the caller provide the AWS Provider like this:

```
provider "aws" {
  region = "us-east-1"
  alias  = "use1"
  max_retries = 10
  access_key = data.vault_aws_access_credentials.creds.access_key
  secret_key = data.vault_aws_access_credentials.creds.secret_key
}

module "odc_eks" {
  source = "github.com/opendatacube/datacube-k8s-eks//odc_eks?ref=make-cf-aws-provider-a-proxy"
  providers = {
    aws.us-east-1 = aws.use1
  }
  # Cluster config
  region          = local.region
  owner           = local.owner
  namespace       = local.namespace
  environment     = local.environment
  cluster_version = 1.17

  admin_access_CIDRs = {
    "Everywhere" = "0.0.0.0/0"
  }
```

Details can be found at https://www.terraform.io/docs/configuration/modules.html#providers-within-modules

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

Yes, callers will need to declare a us-east-1 aws Provider and pass it in via the providers block in the module call.