### PR TITLE
#251 Use application ARN instead of ID

### DIFF
--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -104,9 +104,7 @@ resource "aws_cognito_user_pool_client" "clients" {
   dynamic "analytics_configuration" {
     for_each = var.enable_pinpoint ? [1] : []
     content {
-      application_id   = aws_pinpoint_app.pinpoint_app[each.key].application_id
-      external_id      = each.key
-      role_arn         = aws_iam_role.pinpoint_role[0].arn
+      application_arn   = aws_pinpoint_app.pinpoint_app[each.key].arn
       user_data_shared = true
     }
   }


### PR DESCRIPTION
Closes #251 , by adding tested PinPoint analytics for Cognito.

# Why this change is needed
This change makes cognito + pinpoint analytics functional in regions that are not us-east-1


# Negative effects of this change
Adds new functionality, no negative effects. There are couple of dangling pinpoint roles which will be cleaned up in a separate PR. See follow on issue #263.
