### PR TITLE
expose a new optional variable - enable_s3_endpoint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**
+**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.13.5` on your local setup for this activity.**
 
 # Why this change is needed
 > Describe why this change is needed, what issues it will fix and the benefits the change will add

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -104,7 +104,7 @@ resource "aws_cognito_user_pool_client" "clients" {
   dynamic "analytics_configuration" {
     for_each = var.enable_pinpoint ? [1] : []
     content {
-      application_arn   = aws_pinpoint_app.pinpoint_app[each.key].arn
+      application_arn  = aws_pinpoint_app.pinpoint_app[each.key].arn
       user_data_shared = true
     }
   }

--- a/odc_eks/README.md
+++ b/odc_eks/README.md
@@ -118,6 +118,7 @@ Copy the example to create your own live repo to set up ODC infrastructure to ru
 | public_subnet_cidrs | List of public cidrs, for all available availability zones. Used by VPC module to set up public subnets | list(string) | ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"] | No |
 | private_subnet_cidrs | List of private cidrs, for all available availability zones. Used by VPC module to set up private subnets | list(string) | ["10.0.32.0/19", "10.0.64.0/19", "10.0.96.0/19"] | No |
 | database_subnet_cidrs | List of database cidrs, for all available availability zones. Used by VPC module to set up database subnets | list(string) | ["10.0.20.0/22", "10.0.24.0/22", "10.0.28.0/22"] | No |
+| enable_s3_endpoint | Whether to provision an S3 endpoint to the VPC. Default is set to 'true' | bool | true | No |
 | enable_ec2_ssm | Enables the IAM policy required for AWS EC2 System Manager in the EKS Node IAM role created | bool | true | No |
 | ami_image_id | This variable can be used to deploy a patched / customised version of the Amazon EKS image | string | "" | No |
 | node_group_name | Autoscaling node group name. This name is used to tag instances and ASGs | string | "eks" | No |

--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -44,7 +44,7 @@ module "vpc" {
 
   enable_nat_gateway           = true
   create_database_subnet_group = true
-  enable_s3_endpoint           = true
+  enable_s3_endpoint           = var.enable_s3_endpoint
 
   tags = merge(
     {

--- a/odc_eks/variables.tf
+++ b/odc_eks/variables.tf
@@ -87,6 +87,12 @@ variable "database_subnet_cidrs" {
 
 }
 
+variable "enable_s3_endpoint" {
+  type        = bool
+  description = "Whether to provision an S3 endpoint to the VPC. Default is set to 'true'"
+  default     = true
+}
+
 # EC2 Worker Roles
 # ==================
 variable "enable_ec2_ssm" {


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.12.18` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

expose a new optional variable - `enable_s3_endpoint` and set it's default value to `true`. Needed it exposed for our africa clusters

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

No impact as it is an optional variable with default set to "true"
