### PR TITLE
cognito - support token validity configuration

### DIFF
--- a/cognito/README.md
+++ b/cognito/README.md
@@ -64,6 +64,15 @@ Copy the example to create your own live repo to setup ODC infrastructure to run
         ]
         default_redirect_uri = "app.jupyterhub.example.com"
         explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_CUSTOM_AUTH"]
+        # Optional attribute to override below defaults
+        token_validity_units = {
+          access_token  = "minutes"
+          id_token      = "minutes"
+          refresh_token = "days"
+        }
+        access_token_validity  = 60
+        id_token_validity      = 60
+        refresh_token_validity = 30
       }
     }
     

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -116,9 +116,9 @@ resource "aws_cognito_user_pool_client" "clients" {
   }
 
   token_validity_units {
-    access_token  = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.access_token : each.value.token_validity_units["access_token"]
-    id_token      = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.id_token : each.value.token_validity_units["id_token"]
-    refresh_token = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.refresh_token : each.value.token_validity_units["refresh_token"]
+    access_token  = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.access_token : each.value.token_validity_units.access_token
+    id_token      = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.id_token : each.value.token_validity_units.id_token
+    refresh_token = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.refresh_token : each.value.token_validity_units.refresh_token
   }
   access_token_validity  = lookup(each.value, "access_token_validity", 60)
   id_token_validity      = lookup(each.value, "id_token_validity", 60)

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -116,9 +116,9 @@ resource "aws_cognito_user_pool_client" "clients" {
   }
 
   token_validity_units {
-    access_token  = lookup(each.value, "access_token", null) == null ? local.token_validity_units_default.access_token : each.value.access_token
-    id_token      = lookup(each.value, "id_token", null) == null ? local.token_validity_units_default.id_token : each.value.id_token
-    refresh_token = lookup(each.value, "refresh_token", null) == null ? local.token_validity_units_default.refresh_token : each.value.refresh_token
+    access_token  = lookup(each.value.token_validity_units, "access_token", null) == null ? local.token_validity_units_default.access_token : each.value.token_validity_units["access_token"]
+    id_token      = lookup(each.value.token_validity_units, "id_token", null) == null ? local.token_validity_units_default.id_token : each.value.token_validity_units["id_token"]
+    refresh_token = lookup(each.value.token_validity_units, "refresh_token", null) == null ? local.token_validity_units_default.refresh_token : each.value.token_validity_units["refresh_token"]
   }
   access_token_validity  = lookup(each.value, "access_token_validity", 60)
   id_token_validity      = lookup(each.value, "id_token_validity", 60)

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -83,6 +83,12 @@ locals {
   }
 
   admin_create_user_config = [local.admin_create_user_config_default]
+
+  token_validity_units_default = {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
 }
 
 resource "aws_cognito_user_pool_client" "clients" {
@@ -108,6 +114,16 @@ resource "aws_cognito_user_pool_client" "clients" {
       user_data_shared = true
     }
   }
+
+  token_validity_units {
+    access_token  = lookup(each.value, "access_token", null) == null ? local.token_validity_units_default.access_token : each.value.access_token
+    id_token      = lookup(each.value, "id_token", null) == null ? local.token_validity_units_default.id_token : each.value.id_token
+    refresh_token = lookup(each.value, "refresh_token", null) == null ? local.token_validity_units_default.refresh_token : each.value.refresh_token
+  }
+  access_token_validity  = lookup(each.value, "access_token_validity", 60)
+  id_token_validity      = lookup(each.value, "id_token_validity", 60)
+  refresh_token_validity = lookup(each.value, "refresh_token_validity", 30)
+
 }
 
 resource "aws_cognito_user_pool_domain" "domain" {

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -116,9 +116,9 @@ resource "aws_cognito_user_pool_client" "clients" {
   }
 
   token_validity_units {
-    access_token  = lookup(each.value.token_validity_units, "access_token", null) == null ? local.token_validity_units_default.access_token : each.value.token_validity_units["access_token"]
-    id_token      = lookup(each.value.token_validity_units, "id_token", null) == null ? local.token_validity_units_default.id_token : each.value.token_validity_units["id_token"]
-    refresh_token = lookup(each.value.token_validity_units, "refresh_token", null) == null ? local.token_validity_units_default.refresh_token : each.value.token_validity_units["refresh_token"]
+    access_token  = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.access_token : each.value.token_validity_units["access_token"]
+    id_token      = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.id_token : each.value.token_validity_units["id_token"]
+    refresh_token = lookup(each.value, "token_validity_units", null) == null ? local.token_validity_units_default.refresh_token : each.value.token_validity_units["refresh_token"]
   }
   access_token_validity  = lookup(each.value, "access_token_validity", 60)
   id_token_validity      = lookup(each.value, "id_token_validity", 60)

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -1,6 +1,6 @@
 variable "app_clients" {
   description = "Map of Cognito user pool app clients"
-  type        = map
+  type        = map(any)
 }
 
 variable "user_pool_name" {
@@ -16,7 +16,7 @@ variable "user_pool_domain" {
 variable "user_groups" {
   default     = {}
   description = "Map of Cognito user groups"
-  type        = map
+  type        = map(any)
 }
 
 variable "enable_pinpoint" {
@@ -51,7 +51,7 @@ variable "environment" {
 # admin_create_user_config
 variable "admin_create_user_config" {
   description = "The configuration for AdminCreateUser requests"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 

--- a/odc_eks/versions.tf
+++ b/odc_eks/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.13"
-      configuration_aliases = [ aws.us-east-1 ]
+      source                = "hashicorp/aws"
+      version               = "~> 3.13"
+      configuration_aliases = [aws.us-east-1]
     }
   }
 }

--- a/odc_k8s/fluxcloud.tf
+++ b/odc_k8s/fluxcloud.tf
@@ -55,6 +55,8 @@ resource "kubernetes_service" "fluxcloud" {
       target_port = "3032"
     }
   }
+
+  wait_for_load_balancer = true
 }
 
 resource "kubernetes_deployment" "fluxcloud" {
@@ -81,6 +83,7 @@ resource "kubernetes_deployment" "fluxcloud" {
       }
 
       spec {
+        automount_service_account_token = false
         container {
           name  = "fluxcloud"
           image = "justinbarrick/fluxcloud:v0.3.8"

--- a/odc_k8s/variables.tf
+++ b/odc_k8s/variables.tf
@@ -25,19 +25,19 @@ variable "cluster_id" {
 
 variable "node_roles" {
   default     = {}
-  type        = map
+  type        = map(any)
   description = "A list of node roles that will be given access to the cluster"
 }
 
 variable "user_roles" {
   default     = {}
-  type        = map
+  type        = map(any)
   description = "A list of user roles that will be given access to the cluster"
 }
 
 variable "users" {
   default     = {}
-  type        = map
+  type        = map(any)
   description = "A list of users that will be given access to the cluster"
 }
 

--- a/odc_role/variables.tf
+++ b/odc_role/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_id" {
 }
 
 variable "role" {
-  type        = map
+  type        = map(any)
   description = "Provision a role that can be used by pods/applications on the k8s cluster"
 }
 

--- a/odc_user/variables.tf
+++ b/odc_user/variables.tf
@@ -23,6 +23,6 @@ variable "tags" {
 }
 
 variable "user" {
-  type        = map
+  type        = map(any)
   description = "Provision a user that can be used by pods/applications on the k8s cluster"
 }


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.13.5` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

cognito - support token validity configuration. This is per app-client configuration and it's default is set to below:

```
    token_validity_units = {
      access_token  = "minutes"
      id_token      = "minutes"
      refresh_token = "days"
    }
    access_token_validity  = 60
    id_token_validity      = 60
    refresh_token_validity = 30
```

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

It can impact so make sure either go with defaults or override to your configuration.