### PR TITLE
Upgrades for tf 0.15.x syntax changes

### DIFF
--- a/examples/backend_init/terraform-backend.tf
+++ b/examples/backend_init/terraform-backend.tf
@@ -1,5 +1,5 @@
 module "odc_backend_label" {
-  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace = var.namespace
   stage     = var.environment
   name      = "backend"

--- a/examples/stage/01_odc_eks/odc_eks.tf
+++ b/examples/stage/01_odc_eks/odc_eks.tf
@@ -1,5 +1,5 @@
 module "odc_cluster_label" {
-  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace = local.namespace
   stage     = local.environment
   name      = "eks"

--- a/odc_eks/cloudfront_distribution.tf
+++ b/odc_eks/cloudfront_distribution.tf
@@ -77,10 +77,6 @@ variable "cf_price_class" {
 }
 
 # Create a new certificate, this must be in us-east-1 to work with cloudfront
-provider "aws" {
-  alias = "us-east-1"
-}
-
 resource "aws_acm_certificate" "cert" {
   provider                  = aws.us-east-1
   count                     = (var.cf_certificate_create && var.cf_enable) ? 1 : 0

--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "available" {
 }
 
 module "odc_eks_label" {
-  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.5.0"
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace = var.namespace
   stage     = var.environment
   name      = "eks"

--- a/odc_eks/versions.tf
+++ b/odc_eks/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.13"
+      configuration_aliases = [ aws.us-east-1 ]
+    }
+  }
+}

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -198,7 +198,7 @@ variable "waf_url_whitelist_url_host" {
 }
 
 module "waf_label" {
-  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.5.0"
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace = var.namespace
   stage     = var.environment
   name      = "waf"
@@ -214,7 +214,7 @@ module "waf_label" {
 # - Updates to allow disable specific XSS and PATH based rules filters
 # - Updates to address URL whitelisting
 module "owasp_top_10_rules" {
-  source = "git::https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules.git?ref=master"
+  source = "git::https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules.git?ref=tf-015-compat-fixes"
 
   owner       = var.owner
   namespace   = var.namespace

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -214,7 +214,7 @@ module "waf_label" {
 # - Updates to allow disable specific XSS and PATH based rules filters
 # - Updates to address URL whitelisting
 module "owasp_top_10_rules" {
-  source = "git::https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules.git?ref=tf-015-compat-fixes"
+  source = "git::https://github.com/opendatacube/terraform-aws-waf-owasp-top-10-rules.git?ref=master"
 
   owner       = var.owner
   namespace   = var.namespace


### PR DESCRIPTION
+ deployment label module updated.
+ syntax fixes for WAF (via module version update and related PR)
+ provider alias syntax change for cloudfront aws us-east-1 provider.

**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.15.x` on your local setup for this activity.**

# Why this change is needed
TF 0.15.x fully deprecates some older features - notably list() - and uses a different syntax for provider aliases (no more empty provider blocks).


# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here
THERE SHOULD BE NO CHANGED TO INFRASTRUCTURE FROM THESE CHANGES