### PR TITLE
#19 Add ODC boilerplate contrib guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Firstly, thank you for contributing! We are very grateful for your assistance in improving the Open Data Cube. 
+
+When contributing to this repository, please first discuss the change you wish to make via an issue,
+Slack, or any other method with the owners of this repository before proposing a change.
+
+We have a [code of conduct](code-of-conduct.md), so please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+When you create a Pull Request, there is a template defined that has required information. Please complete this template to ensure that we can review the PR easily.
+
+## Enhancement proposals
+
+We have a [Steering Council](https://github.com/opendatacube/datacube-core/wiki/steering-council) who discuss
+and consider major enhancements, and there are a number of [current and past enhancement proposals](https://github.com/opendatacube/datacube-core/wiki/enhancement-proposals) documented.
+
+
+## Links
+
+In case you haven't found them yet, please checkout the following resources:
+
+* [Documentation](https://datacube-core.readthedocs.io/en/latest/)
+* [Slack](http://slack.opendatacube.org)
+* [GIS Stack Exchange](https://gis.stackexchange.com/questions/tagged/open-data-cube).


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version `v0.13.5` on your local setup for this activity.**

# Why this change is needed
Closes #19 


# Negative effects of this change
Will require repository specific refinements.
