### PR TITLE
Vpc creation optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# v1.10.0 odc_eks - Optional vpc creation update procedure
+
+Making VPC creation optional has added a `count` to the `module.odc_eks.module.vpc` resource path.
+Use `terraform state mv` to move existing`module.odc_eks.module.vpc` resources to `module.odc_eks.module.vpc[0]`. Suitable commands are below.
+
+Result:
+  * Terraform Apply will show no change in infrastructure for default configuration of `vpc_create = true`
+  * Outputs may be reported as updated (`database_subnet`) but the values will be identical and there will be no upstream impacts.
+
+```
+terraform state mv module.odc_eks.module.vpc.data.aws_vpc_endpoint_service.s3[0] module.odc_eks.module.vpc[0].data.aws_vpc_endpoint_service.s3[0]
+terraform state mv module.odc_eks.module.vpc.aws_db_subnet_group.database[0] module.odc_eks.module.vpc[0].aws_db_subnet_group.database[0]
+terraform state mv module.odc_eks.module.vpc.aws_eip.nat[0] module.odc_eks.module.vpc[0].aws_eip.nat[0]
+terraform state mv module.odc_eks.module.vpc.aws_eip.nat[1] module.odc_eks.module.vpc[0].aws_eip.nat[1]
+terraform state mv module.odc_eks.module.vpc.aws_eip.nat[2] module.odc_eks.module.vpc[0].aws_eip.nat[2]
+terraform state mv module.odc_eks.module.vpc.aws_internet_gateway.this[0] module.odc_eks.module.vpc[0].aws_internet_gateway.this[0]
+terraform state mv module.odc_eks.module.vpc.aws_nat_gateway.this[0] module.odc_eks.module.vpc[0].aws_nat_gateway.this[0]
+terraform state mv module.odc_eks.module.vpc.aws_nat_gateway.this[1] module.odc_eks.module.vpc[0].aws_nat_gateway.this[1]
+terraform state mv module.odc_eks.module.vpc.aws_nat_gateway.this[2] module.odc_eks.module.vpc[0].aws_nat_gateway.this[2]
+terraform state mv module.odc_eks.module.vpc.aws_route.private_nat_gateway[0] module.odc_eks.module.vpc[0].aws_route.private_nat_gateway[0]
+terraform state mv module.odc_eks.module.vpc.aws_route.private_nat_gateway[1] module.odc_eks.module.vpc[0].aws_route.private_nat_gateway[1]
+terraform state mv module.odc_eks.module.vpc.aws_route.private_nat_gateway[2] module.odc_eks.module.vpc[0].aws_route.private_nat_gateway[2]
+terraform state mv module.odc_eks.module.vpc.aws_route.public_internet_gateway[0] module.odc_eks.module.vpc[0].aws_route.public_internet_gateway[0]
+terraform state mv module.odc_eks.module.vpc.aws_route_table.private[0] module.odc_eks.module.vpc[0].aws_route_table.private[0]
+terraform state mv module.odc_eks.module.vpc.aws_route_table.private[1] module.odc_eks.module.vpc[0].aws_route_table.private[1]
+terraform state mv module.odc_eks.module.vpc.aws_route_table.private[2] module.odc_eks.module.vpc[0].aws_route_table.private[2]
+terraform state mv module.odc_eks.module.vpc.aws_route_table.public[0] module.odc_eks.module.vpc[0].aws_route_table.public[0]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.database[0] module.odc_eks.module.vpc[0].aws_route_table_association.database[0]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.database[1] module.odc_eks.module.vpc[0].aws_route_table_association.database[1]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.database[2] module.odc_eks.module.vpc[0].aws_route_table_association.database[2]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.private[0] module.odc_eks.module.vpc[0].aws_route_table_association.private[0]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.private[1] module.odc_eks.module.vpc[0].aws_route_table_association.private[1]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.private[2] module.odc_eks.module.vpc[0].aws_route_table_association.private[2]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.public[0] module.odc_eks.module.vpc[0].aws_route_table_association.public[0]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.public[1] module.odc_eks.module.vpc[0].aws_route_table_association.public[1]
+terraform state mv module.odc_eks.module.vpc.aws_route_table_association.public[2] module.odc_eks.module.vpc[0].aws_route_table_association.public[2]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.database[0] module.odc_eks.module.vpc[0].aws_subnet.database[0]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.database[1] module.odc_eks.module.vpc[0].aws_subnet.database[1]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.database[2] module.odc_eks.module.vpc[0].aws_subnet.database[2]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.private[0] module.odc_eks.module.vpc[0].aws_subnet.private[0]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.private[1] module.odc_eks.module.vpc[0].aws_subnet.private[1]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.private[2] module.odc_eks.module.vpc[0].aws_subnet.private[2]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.public[0] module.odc_eks.module.vpc[0].aws_subnet.public[0]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.public[1] module.odc_eks.module.vpc[0].aws_subnet.public[1]
+terraform state mv module.odc_eks.module.vpc.aws_subnet.public[2] module.odc_eks.module.vpc[0].aws_subnet.public[2]
+terraform state mv module.odc_eks.module.vpc.aws_vpc.this[0] module.odc_eks.module.vpc[0].aws_vpc.this[0]
+terraform state mv module.odc_eks.module.vpc.aws_vpc_endpoint.s3[0] module.odc_eks.module.vpc[0].aws_vpc_endpoint.s3[0]
+terraform state mv module.odc_eks.module.vpc.aws_vpc_endpoint_route_table_association.private_s3[0] module.odc_eks.module.vpc[0].aws_vpc_endpoint_route_table_association.private_s3[0]
+terraform state mv module.odc_eks.module.vpc.aws_vpc_endpoint_route_table_association.private_s3[1] module.odc_eks.module.vpc[0].aws_vpc_endpoint_route_table_association.private_s3[1]
+terraform state mv module.odc_eks.module.vpc.aws_vpc_endpoint_route_table_association.private_s3[2] module.odc_eks.module.vpc[0].aws_vpc_endpoint_route_table_association.private_s3[2]
+terraform state mv module.odc_eks.module.vpc.aws_vpc_endpoint_route_table_association.public_s3[0] module.odc_eks.module.vpc[0].aws_vpc_endpoint_route_table_association.public_s3[0]
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Result:
   * Outputs may be reported as updated (`database_subnet`) but the values will be identical and there will be no upstream impacts.
 
 ```
+terraform state mv module.odc_eks.module.vpc module.odc_eks.module.vpc[0]
 terraform state mv module.odc_eks.module.vpc.data.aws_vpc_endpoint_service.s3[0] module.odc_eks.module.vpc[0].data.aws_vpc_endpoint_service.s3[0]
 terraform state mv module.odc_eks.module.vpc.aws_db_subnet_group.database[0] module.odc_eks.module.vpc[0].aws_db_subnet_group.database[0]
 terraform state mv module.odc_eks.module.vpc.aws_eip.nat[0] module.odc_eks.module.vpc[0].aws_eip.nat[0]

--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -16,6 +16,8 @@ locals {
 module "vpc" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v2.70.0"
 
+  count = var.create_vpc ? 1 : 0
+
   name             = "${local.cluster_id}-vpc"
   cidr             = var.vpc_cidr
   azs              = data.aws_availability_zones.available.names
@@ -60,8 +62,8 @@ module "vpc" {
 # Creates network and Kuberenetes master nodes
 module "eks" {
   source             = "./modules/eks"
-  vpc_id             = module.vpc.vpc_id
-  eks_subnet_ids     = module.vpc.private_subnets
+  vpc_id             = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
+  eks_subnet_ids     = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
   cluster_id         = local.cluster_id
   cluster_version    = var.cluster_version
   admin_access_CIDRs = var.admin_access_CIDRs

--- a/odc_eks/outputs.tf
+++ b/odc_eks/outputs.tf
@@ -57,17 +57,17 @@ output "waf_acl_id" {
 }
 
 output "vpc_id" {
-  value = module.vpc.vpc_id
+  value = var.create_vpc ? module.vpc[0].vpc_id : ""
 }
 
 output "database_subnets" {
-  value = module.vpc.database_subnets
+  value = var.create_vpc ? module.vpc[0].database_subnets : var.database_subnets
 }
 
 output "private_subnets" {
-  value = module.vpc.private_subnets
+  value = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
 }
 
 output "public_route_table_ids" {
-  value = module.vpc.public_route_table_ids
+  value = var.create_vpc ? module.vpc[0].public_route_table_ids : var.public_route_table_ids
 }

--- a/odc_eks/outputs.tf
+++ b/odc_eks/outputs.tf
@@ -57,7 +57,7 @@ output "waf_acl_id" {
 }
 
 output "vpc_id" {
-  value = var.create_vpc ? module.vpc[0].vpc_id : ""
+  value = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
 }
 
 output "database_subnets" {

--- a/odc_eks/variables.tf
+++ b/odc_eks/variables.tf
@@ -63,28 +63,58 @@ variable "create_certificate" {
 
 # VPC & subnets
 # =================
+variable "create_vpc" {
+  type        = bool
+  description = "Whether to create the VPC and subnets or to supply them. If supplied then subnets and tagging must be configured correctly for AWS EKS use - see AWS EKS VPC requirments documentation"
+  default = true
+}
+## Create VPC = false
+variable "vpc_id" {
+  type = string
+  description = "VPC ID to use if create_vpc = false"
+  default = ""
+}
+
+variable "private_subnets" {
+  type = list(string)
+  description = "list of private subnets to use if create_vpc = false"
+  default = []
+}
+
+variable "database_subnets" {
+  type = list(string)
+  description = "list of database subnets to use if create_vpc = false"
+  default = []
+}
+
+variable "public_route_table_ids" {
+  type = string
+  description = "Will just pass through to outputs if use create_vpc = false. For backwards compatibility."
+  default = ""
+}
+
+## Create VPC = true
 variable "vpc_cidr" {
   type    = string
   default = "10.0.0.0/16"
 }
 
-
 variable "public_subnet_cidrs" {
   description = "List of public cidrs, for all available availability zones. Example: 10.0.0.0/24 and 10.0.1.0/24"
   type        = list(string)
-
+  default = []
 }
 
 variable "private_subnet_cidrs" {
   description = "List of private cidrs, for all available availability zones. Example: 10.0.0.0/24 and 10.0.1.0/24"
   type        = list(string)
-
+  default = []
 }
 
 variable "database_subnet_cidrs" {
   description = "List of database cidrs, for all available availability zones. Example: 10.0.0.0/24 and 10.0.1.0/24"
   type        = list(string)
-
+  default = []
 }
 
 variable "enable_s3_endpoint" {

--- a/odc_eks/variables.tf
+++ b/odc_eks/variables.tf
@@ -88,9 +88,9 @@ variable "database_subnets" {
 }
 
 variable "public_route_table_ids" {
-  type = string
+  type = list(string)
   description = "Will just pass through to outputs if use create_vpc = false. For backwards compatibility."
-  default = ""
+  default = []
 }
 
 ## Create VPC = true


### PR DESCRIPTION
# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

Some deployments have IT requirements that necessitate the use of an alternate VPC configuration to the default created by the `odc_eks` module. This PR makes VPC creation optional and allows for the VPC and subnets to be supplied to the `odc_eks` module.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

Making `odc_eks.module.vpc` optional adds a `count` and the resource path for the default `create_vpc = true` configuraiton changes to `odc_eks.module.vpc[0]`. It is thus necessary to `terrafrom state mv` all of these resources to the new path. The new `CHANGELOG.md` contains the necessary commands.
Once the resource names are updated there is _no change to infrastructure_ on `terraform plan`.

Since the state mv is required but the outcome is no change it is proposed the version tag for this release be a minor version increment to `v1.10.0` as reflected in the CHANGELOG.md

Note:
  * If the terraform state is not moved to the new path prior to terraform plan then the plan will fail with the kuberenetes provider and resources throwing errors about not being able to connect to the kubernetes cluster (which it can't because the vpc doesn't exist in the new resource path)
  * Terraform outputs will show as being updated in the terraform plan but the output is identical. This appears to be an internal change due to the new module path for the output but has no impact downstream as the value is identical. 
