### PR TITLE
add prometheus monitoring setting to flux chart

### DIFF
--- a/odc_k8s/README.md
+++ b/odc_k8s/README.md
@@ -176,6 +176,7 @@ module "odc_k8s" {
 | flux_helm_operator_version   | Flux helm-operator release version                                                                              | string                                                                         | "1.0.1"                                                  | No       |
 | flux_registry_ecr            | Use flux_registry_ecr for fluxcd ecr configuration                                                              | object({regions=list(string) includeIds=list(string) excludeIds=list(string)}) | { regions=[] includeIds=[] excludeIds=["602401143452"] } | No       |
 | flux_service_account_arn     | provide flux OIDC service account role arn                                                                      | string                                                                         | ""                                                       | No       |
+| flux_monitoring              | If true, enable prometheus metrics            | false                                                    | No       |
 | enabled_helm_versions        | Helm options to support release versions. Valid values: `"v2"`/`"v3"`/`"v2\\,v3"`                               | string                                                                         | "v2\\,v3"                                                | No       |
 
 ### Inputs - FluxCloud

--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -29,3 +29,11 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: "${service_account_arn}"
 %{ endif }
+%{ if monitoring }
+prometheus:
+  enabled: true
+dashboard:
+  enabled: true
+  namespace: monitoring
+  nameprefix: flux-dashboard
+%{ endif }

--- a/odc_k8s/flux.tf
+++ b/odc_k8s/flux.tf
@@ -51,6 +51,12 @@ variable "flux_service_account_arn" {
   default     = ""
 }
 
+variable "flux_monitoring" {
+  description = "Whether to enable prometheus monitoring"
+  type        = bool
+  default     = false
+}
+
 variable "flux_registry_ecr" {
   description = "Use flux_registry_ecr for fluxcd ecr configuration"
   type = object({
@@ -95,6 +101,7 @@ resource "helm_release" "flux" {
       registry_exclude_images = var.flux_registry_exclude_images
       flux_registry_ecr       = var.flux_registry_ecr
       service_account_arn     = var.flux_service_account_arn
+      monitoring              = var.flux_monitoring
     })
   ]
 }


### PR DESCRIPTION
# Why this change is needed
flux helm chart supports Prometheus metrics https://github.com/fluxcd/flux/blob/master/chart/flux/values.yaml#L301-L309  and offers a grafana dashboard https://github.com/fluxcd/flux/blob/master/chart/flux/values.yaml#L342-L349

We are looking to increase system visibility via Prometheus metrics and grafana dashboard, enabling this feature will provide us some basic visibility we need.

# Negative effects of this change
This is an additional feature and will not break existing setup.