### PR TITLE
fix typo change dashboard to dashboards

### DIFF
--- a/odc_k8s/config/flux.yaml
+++ b/odc_k8s/config/flux.yaml
@@ -32,7 +32,7 @@ serviceAccount:
 %{ if monitoring }
 prometheus:
   enabled: true
-dashboard:
+dashboards:
   enabled: true
   namespace: monitoring
   nameprefix: flux-dashboard


### PR DESCRIPTION
Tested in dea-dev

# Why this change is needed
the helm value should be `dashboards`, this pr is to correct the typo.

# Negative effects of this change
No.