### PR TITLE
Include var.tags in node workers

### DIFF
--- a/odc_eks/modules/eks/main.tf
+++ b/odc_eks/modules/eks/main.tf
@@ -13,13 +13,16 @@ resource "aws_eks_cluster" "eks" {
     aws_iam_role_policy_attachment.eks-cluster-AmazonEKSServicePolicy,
   ]
 
-  tags = {
-    Name        = var.cluster_id
-    Cluster     = var.cluster_id
-    Owner       = var.owner
-    Namespace   = var.namespace
-    Environment = var.environment
-  }
+  tags = merge(
+    {
+      Name        = var.cluster_id
+      cluster     = var.cluster_id
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "null_resource" "wait_for_cluster" {

--- a/odc_eks/modules/eks/workers.tf
+++ b/odc_eks/modules/eks/workers.tf
@@ -16,9 +16,17 @@ resource "aws_autoscaling_group" "nodes" {
     version = aws_launch_template.node.latest_version
   }
 
-  # Use a dyanmic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
+  # Use a dynamic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
   dynamic "tag" {
     for_each = concat(
+      flatten([
+        for key in keys(var.tags) :
+        {
+          key                 = key
+          value               = var.tags[key]
+          propagate_at_launch = true
+        }
+      ]),
       flatten([
         for key in keys(var.node_extra_tags) :
         {
@@ -101,9 +109,17 @@ resource "aws_autoscaling_group" "spot_nodes" {
     version = aws_launch_template.spot[0].latest_version
   }
 
-  # Use a dyanmic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
+  # Use a dynamic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
   dynamic "tag" {
     for_each = concat(
+      flatten([
+        for key in keys(var.tags) :
+        {
+          key                 = key
+          value               = var.tags[key]
+          propagate_at_launch = true
+        }
+      ]),
       flatten([
         for key in keys(var.node_extra_tags) :
         {

--- a/odc_eks/modules/eks/workers.tf
+++ b/odc_eks/modules/eks/workers.tf
@@ -18,69 +18,25 @@ resource "aws_autoscaling_group" "nodes" {
 
   # Use a dynamic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
   dynamic "tag" {
-    for_each = concat(
-      flatten([
-        for key in keys(var.tags) :
-        {
-          key                 = key
-          value               = var.tags[key]
-          propagate_at_launch = true
-        }
-      ]),
-      flatten([
-        for key in keys(var.node_extra_tags) :
-        {
-          key                 = key
-          value               = var.node_extra_tags[key]
-          propagate_at_launch = true
-        }
-      ]),
-      [
-        {
-          key                 = "Name"
-          value               = "${var.node_group_name}-${aws_launch_template.node.id}-nodes"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "environment"
-          value               = var.environment
-          propagate_at_launch = true
-        },
-        {
-          key                 = "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"
-          value               = "owned"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "k8s.io/cluster-autoscaler/enabled"
-          value               = "true"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "k8s.io/cluster-autoscaler/node-template/label/nodetype"
-          value               = "ondemand"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"
-          value               = "owned"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "namespace"
-          value               = var.namespace
-          propagate_at_launch = true
-        },
-        {
-          key                 = "owner"
-          value               = var.owner
-          propagate_at_launch = true
-        },
-    ])
+    for_each = merge(
+      {
+        Name        = "${var.node_group_name}-${aws_launch_template.node.id}-nodes"
+        environment = var.environment
+        namespace   = var.namespace
+        owner       = var.owner
+
+        "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"    = "owned"
+        "k8s.io/cluster-autoscaler/enabled"                      = "true"
+        "k8s.io/cluster-autoscaler/node-template/label/nodetype" = "ondemand"
+        "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"        = "owned"
+      },
+      var.tags,
+      var.node_extra_tags
+    )
     content {
-      key                 = tag.value.key
-      value               = tag.value.value
-      propagate_at_launch = tag.value.propagate_at_launch
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
     }
   }
 
@@ -111,72 +67,27 @@ resource "aws_autoscaling_group" "spot_nodes" {
 
   # Use a dynamic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
   dynamic "tag" {
-    for_each = concat(
-      flatten([
-        for key in keys(var.tags) :
-        {
-          key                 = key
-          value               = var.tags[key]
-          propagate_at_launch = true
-        }
-      ]),
-      flatten([
-        for key in keys(var.node_extra_tags) :
-        {
-          key                 = key
-          value               = var.node_extra_tags[key]
-          propagate_at_launch = true
-        }
-      ]),
-      [
-        {
-          key                 = "Name"
-          value               = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "environment"
-          value               = var.environment
-          propagate_at_launch = true
-        },
-        {
-          key                 = "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"
-          value               = "owned"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "k8s.io/cluster-autoscaler/enabled"
-          value               = "true"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "k8s.io/cluster-autoscaler/node-template/label/nodetype"
-          value               = "spot"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"
-          value               = "owned"
-          propagate_at_launch = true
-        },
-        {
-          key                 = "namespace"
-          value               = var.namespace
-          propagate_at_launch = true
-        },
-        {
-          key                 = "owner"
-          value               = var.owner
-          propagate_at_launch = true
-        },
-    ])
+    for_each = merge(
+      {
+        Name        = "${var.node_group_name}-${aws_launch_template.spot[0].id}-spot"
+        environment = var.environment
+        namespace   = var.namespace
+        owner       = var.owner
+
+        "k8s.io/cluster-autoscaler/${aws_eks_cluster.eks.id}"    = "owned"
+        "k8s.io/cluster-autoscaler/enabled"                      = "true"
+        "k8s.io/cluster-autoscaler/node-template/label/nodetype" = "true"
+        "kubernetes.io/cluster/${aws_eks_cluster.eks.id}"        = "owned"
+      },
+      var.tags,
+      var.node_extra_tags
+    )
     content {
-      key                 = tag.value.key
-      value               = tag.value.value
-      propagate_at_launch = tag.value.propagate_at_launch
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
     }
   }
-
 
   # Don't break cluster autoscaler
   suspended_processes = ["AZRebalance"]


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

I want to track costs of infra-dev in Cloudability by tag, and I can see most resources using the `stack_name` tag - except the EC2 worker nodes. Only `var.node_extra_tags` currently get passed, not `var.tags` - like every other resource.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

It shouldn't make any difference other than adding additional generic tags. Unless there was some reason to only include `var.node_extra_tags`, which would otherwise break something if generic `var.tags` were included.

Sample `terraform plan` for infra-dev seems to preserve existing tags - i.e., _"# (9 unchanged blocks hidden)"_ - and includes new tags.

<details>
<summary>Expand terraform plan</summary>

```terraform
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.cognito_user_auth.aws_cognito_user_pool.pool has changed
  ~ resource "aws_cognito_user_pool" "pool" {
        id                        = "ap-southeast-2_TLceJMzTO"
      ~ last_modified_date        = "2022-02-01T00:07:20Z" -> "2022-02-02T02:36:29Z"
        name                      = "infra-dev-eks-user-auth"
        tags                      = {
            "Name"        = "infra-dev-eks-user-auth"
            "branch"      = "NEMO"
            "cost_code"   = ""
            "department"  = "geoscience australia"
            "division"    = "EGD"
            "environment" = "dev"
            "namespace"   = "infra"
            "owner"       = "deacepticons"
            "project"     = "DEA"
            "section"     = "Digital Earth Australia"
            "stack_name"  = "infra-dev-eks"
        }
        # (9 unchanged attributes hidden)







        # (8 unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may
include actions to undo or respond to these changes.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # data.aws_acm_certificate.domain_cert will be read during apply
  # (config refers to values not yet known)
 <= data "aws_acm_certificate" "domain_cert"  {
      ~ arn         = "arn:aws:acm:ap-southeast-2:451924316694:certificate/b5e08874-4245-4ce8-9db4-5bbad43e79ad" -> (known after apply)
      ~ id          = "arn:aws:acm:ap-southeast-2:451924316694:certificate/b5e08874-4245-4ce8-9db4-5bbad43e79ad" -> (known after apply)
      ~ status      = "ISSUED" -> (known after apply)
      ~ tags        = {} -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.odc_eks.module.eks.aws_autoscaling_group.nodes will be updated in-place
  ~ resource "aws_autoscaling_group" "nodes" {
        id                        = "eks-lt-0083e4a903d5c7a21-nodes"
        name                      = "eks-lt-0083e4a903d5c7a21-nodes"
        # (22 unchanged attributes hidden)

      ~ launch_template {
            id      = "lt-0083e4a903d5c7a21"
            name    = "infra-dev-eks2022012402435993510000000c"
          ~ version = "2" -> (known after apply)
        }

      + tag {
          + key                 = "branch"
          + propagate_at_launch = true
          + value               = "NEMO"
        }
      + tag {
          + key                 = "cost_code"
          + propagate_at_launch = true
        }
      + tag {
          + key                 = "department"
          + propagate_at_launch = true
          + value               = "geoscience australia"
        }
      + tag {
          + key                 = "division"
          + propagate_at_launch = true
          + value               = "EGD"
        }
      + tag {
          + key                 = "project"
          + propagate_at_launch = true
          + value               = "DEA"
        }
      + tag {
          + key                 = "section"
          + propagate_at_launch = true
          + value               = "Digital Earth Australia"
        }
      + tag {
          + key                 = "stack_name"
          + propagate_at_launch = true
          + value               = "infra-dev-eks"
        }
        # (9 unchanged blocks hidden)
    }

  # module.odc_eks.module.eks.aws_autoscaling_group.spot_nodes[0] will be updated in-place
  ~ resource "aws_autoscaling_group" "spot_nodes" {
        id                        = "eks-lt-01b63475212926cf3-spot"
        name                      = "eks-lt-01b63475212926cf3-spot"
        # (22 unchanged attributes hidden)

      ~ launch_template {
            id      = "lt-01b63475212926cf3"
            name    = "infra-dev-eks2022012402435993490000000b"
          ~ version = "2" -> (known after apply)
        }

      + tag {
          + key                 = "branch"
          + propagate_at_launch = true
          + value               = "NEMO"
        }
      + tag {
          + key                 = "cost_code"
          + propagate_at_launch = true
        }
      + tag {
          + key                 = "department"
          + propagate_at_launch = true
          + value               = "geoscience australia"
        }
      + tag {
          + key                 = "division"
          + propagate_at_launch = true
          + value               = "EGD"
        }
      + tag {
          + key                 = "project"
          + propagate_at_launch = true
          + value               = "DEA"
        }
      + tag {
          + key                 = "section"
          + propagate_at_launch = true
          + value               = "Digital Earth Australia"
        }
      + tag {
          + key                 = "stack_name"
          + propagate_at_launch = true
          + value               = "infra-dev-eks"
        }
        # (9 unchanged blocks hidden)
    }

  # module.odc_eks.module.eks.aws_launch_template.node will be updated in-place
  ~ resource "aws_launch_template" "node" {
        id                      = "lt-0083e4a903d5c7a21"
      ~ latest_version          = 2 -> (known after apply)
        name                    = "infra-dev-eks2022012402435993510000000c"
        tags                    = {}
      ~ user_data               = "IyEvYmluL2Jh... <snip>" -> "IyEvYmluL2Jhc2gKc2V... <snip"
        # (9 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

  # module.odc_eks.module.eks.aws_launch_template.spot[0] will be updated in-place
  ~ resource "aws_launch_template" "spot" {
        id                      = "lt-01b63475212926cf3"
      ~ latest_version          = 2 -> (known after apply)
        name                    = "infra-dev-eks2022012402435993490000000b"
        tags                    = {}
      ~ user_data               = "IyEvYmluL2... <snip>" -> "IyEvYmluL2Jhc2gKc2V... <snip>"
```

</details>