### PR TITLE
Terraform aws provider v4.0.0 updates

### DIFF
--- a/examples/backend_init/terraform-backend.tf
+++ b/examples/backend_init/terraform-backend.tf
@@ -16,26 +16,35 @@ module "odc_backend_label" {
 # create an S3 bucket to store the state file in
 resource "aws_s3_bucket" "terraform-state-storage-s3" {
   bucket = "${module.odc_backend_label.id}-tfstate"
-  acl    = "private"
-
-  versioning {
-    enabled = true
-  }
 
   # Uncomment this to prevent unintended destruction of state
   # lifecycle {
   #   prevent_destroy = true
   # }
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+  tags = module.odc_backend_label.tags
+}
+
+resource "aws_s3_bucket_acl" "terraform-state-storage-s3" {
+  bucket = aws_s3_bucket.terraform-state-storage-s3.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "terraform-state-storage-s3" {
+  bucket = aws_s3_bucket.terraform-state-storage-s3.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform-state-storage-s3" {
+  bucket = aws_s3_bucket.terraform-state-storage-s3.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
-
-  tags = module.odc_backend_label.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "terraform-state-storage-s3" {

--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -1,5 +1,7 @@
-data "aws_availability_zones" "available" {
-}
+data "aws_availability_zones" "available" {}
+data "aws_caller_identity" "current" {}
+data "aws_canonical_user_id" "current" {}
+data "aws_cloudfront_log_delivery_canonical_user_id" "awslogsdelivery" {}
 
 module "odc_eks_label" {
   source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"

--- a/odc_eks/outputs.tf
+++ b/odc_eks/outputs.tf
@@ -43,9 +43,6 @@ output "ami_image_id" {
   value = module.eks.ami_image_id
 }
 
-data "aws_caller_identity" "current" {
-}
-
 # The length check here is to prevent destroy plans referencing the wildcard_cert[0] value which doesn't exist on destroy
 output "certificate_arn" {
   value = (var.create_certificate && (length(aws_acm_certificate.wildcard_cert) > 0)) ? aws_acm_certificate.wildcard_cert[0].arn : null

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -286,15 +286,6 @@ resource "aws_wafregional_rate_based_rule" "rate_limiter_rule" {
 resource "aws_s3_bucket" "waf_log_bucket" {
   count  = (var.waf_log_bucket_create && var.waf_enable) ? 1 : 0
   bucket = var.waf_log_bucket
-  acl    = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
 
   tags = merge(
     {
@@ -305,6 +296,23 @@ resource "aws_s3_bucket" "waf_log_bucket" {
     },
     var.tags
   )
+}
+
+resource "aws_s3_bucket_acl" "argo_artifact_bucket" {
+  count  = (var.waf_log_bucket_create && var.waf_enable) ? 1 : 0
+  bucket = aws_s3_bucket.waf_log_bucket[0].id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "waf_log_bucket" {
+  count  = (var.waf_log_bucket_create && var.waf_enable) ? 1 : 0
+  bucket = aws_s3_bucket.waf_log_bucket[0].bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 data "aws_s3_bucket" "waf_log_bucket" {

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -298,7 +298,7 @@ resource "aws_s3_bucket" "waf_log_bucket" {
   )
 }
 
-resource "aws_s3_bucket_acl" "argo_artifact_bucket" {
+resource "aws_s3_bucket_acl" "waf_log_bucket" {
   count  = (var.waf_log_bucket_create && var.waf_enable) ? 1 : 0
   bucket = aws_s3_bucket.waf_log_bucket[0].id
   acl    = "private"


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed
> Describe why this change is needed, what issues it will fix and the benefits the change will add

The recent release of `terraform-aws-provider` `v4.0.0` has remove support for some of the `aws_s3_bucket` resource configurations. This PR update/fix those changes. Refer release [v4.0.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0) for more detail.

# Negative effects of this change
> Will making this change break or change an existing functionality? flag it here

Reapply bucket configurations.