### PR TITLE
Cognito phone verification

### DIFF
--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -29,7 +29,7 @@ resource "aws_cognito_user_pool" "pool" {
   name                     = var.user_pool_name
   alias_attributes         = var.alias_attributes != null ? var.alias_attributes : local.alias_attributes
   username_attributes      = var.username_attributes
-  auto_verified_attributes = var.auto_verify ? ["email"] : null
+  auto_verified_attributes = var.auto_verify ? var.auto_verified_attributes : null
 
   schema {
     name                = "email"
@@ -125,6 +125,9 @@ resource "aws_cognito_user_pool" "pool" {
   lifecycle {
     # Enable prevent destroy
     # prevent_destroy = true
+    ignore_changes = [
+      lambda_config  # Create these linkages with a null_resource to avoid circular dependencies
+    ]
   }
 
   tags = merge(

--- a/cognito/cognito_auth.tf
+++ b/cognito/cognito_auth.tf
@@ -126,7 +126,7 @@ resource "aws_cognito_user_pool" "pool" {
     # Enable prevent destroy
     # prevent_destroy = true
     ignore_changes = [
-      lambda_config  # Create these linkages with a null_resource to avoid circular dependencies
+      lambda_config # Create these linkages with a null_resource to avoid circular dependencies
     ]
   }
 

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -30,6 +30,12 @@ variable "auto_verify" {
   type        = bool
 }
 
+variable "auto_verified_attributes" {
+  description = "If auto_verify is true, which fields to auto verify. Valid values are: email, phone_number"
+  type        = set(string)
+  default     = [ "email" ]
+}
+
 variable "alias_attributes" {
   type        = set(string)
   description = "(Optional) Attributes supported as an alias for this user pool. Possible values: 'phone_number', 'email', or 'preferred_username'. Conflicts with username_attributes."

--- a/cognito/variables.tf
+++ b/cognito/variables.tf
@@ -33,7 +33,7 @@ variable "auto_verify" {
 variable "auto_verified_attributes" {
   description = "If auto_verify is true, which fields to auto verify. Valid values are: email, phone_number"
   type        = set(string)
-  default     = [ "email" ]
+  default     = ["email"]
 }
 
 variable "alias_attributes" {


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed
We are moving to require a verified phone_number for new users so we need to override the auto_verified_attributes parameter. I've also set Terraform to ignore changes in user_pool.lambda_config as that's better managed by a null_resource to avoid circular references (ie: user_pool referencing lambda functions which reference the user_pool).


# Negative effects of this change
This shouldn't negatively affect existing installations.
