### PR TITLE
Added explicit dependency to avoid an intermittent race condition

### DIFF
--- a/odc_k8s/fluxcloud.tf
+++ b/odc_k8s/fluxcloud.tf
@@ -134,4 +134,9 @@ resource "kubernetes_deployment" "fluxcloud" {
       type = "Recreate"
     }
   }
+
+  depends_on = [
+    kubernetes_namespace.flux[0]
+  ]
+
 }


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed

During repeated setup/teardown tests on our infra cluster, I frequently had flux failing to create due to its' namespace not yet existing. This simply adds an explicit dependency to prevent that.


# Negative effects of this change

No functional changes.
