### PR TITLE
Added controls for EKS cluster logging to CloudWatch Logs

### DIFF
--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -73,7 +73,8 @@ module "eks" {
   user_custom_policy         = var.user_custom_policy
   user_additional_policy_arn = var.user_additional_policy_arn
 
-  enable_ec2_ssm = var.enable_ec2_ssm
+  enable_ec2_ssm            = var.enable_ec2_ssm
+  enabled_cluster_log_types = var.enabled_cluster_log_types
 
   # Worker configuration
   min_nodes                    = var.min_nodes

--- a/odc_eks/modules/eks/main.tf
+++ b/odc_eks/modules/eks/main.tf
@@ -8,6 +8,8 @@ resource "aws_eks_cluster" "eks" {
     subnet_ids         = var.eks_subnet_ids
   }
 
+  enabled_cluster_log_types = var.enabled_cluster_log_types
+
   depends_on = [
     aws_iam_role_policy_attachment.eks-cluster-AmazonEKSClusterPolicy,
     aws_iam_role_policy_attachment.eks-cluster-AmazonEKSServicePolicy,

--- a/odc_eks/modules/eks/variables.tf
+++ b/odc_eks/modules/eks/variables.tf
@@ -27,6 +27,12 @@ variable "enable_ec2_ssm" {
   description = "Enables the IAM policy required for AWS EC2 System Manager."
 }
 
+variable "enabled_cluster_log_types" {
+  description = "List of the desired control plane logging channels to enable. Allowed values: api, audit, authenticator, controllerManager, scheduler"
+  type        = list(string)
+  default     = []
+}
+
 variable "user_custom_policy" {
   description = "The IAM custom policy to create and attach to EKS user role"
   type        = string

--- a/odc_eks/variables.tf
+++ b/odc_eks/variables.tf
@@ -123,6 +123,12 @@ variable "enable_s3_endpoint" {
   default     = true
 }
 
+variable "enabled_cluster_log_types" {
+  description = "List of the desired control plane logging channels to enable. Allowed values: api, audit, authenticator, controllerManager, scheduler"
+  type        = list(string)
+  default     = []
+}
+
 # EC2 Worker Roles
 # ==================
 variable "enable_ec2_ssm" {


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed

If you enable EKS logging in the console, it will be disabled again the next time you deploy.


# Negative effects of this change

Defaults to disabled so there is no change if not explicitly configured.
