### PR TITLE
Updates for AWS provider v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# master
+
+* The update to the version of Terraform AWS VPC module will require the following manual edits to the state file:
+
+```bash
+terraform state rm module.odc_eks.module.vpc[0].aws_vpc_endpoint_route_table_association.private_s3
+terraform state rm module.odc_eks.module.vpc[0].aws_vpc_endpoint_route_table_association.public_s3
+```
+
+See Terraform AWS VPC module upgrade instructions at https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/fbd4ff646b4caaa6fcc1fb71bc88d377cc8b3b48/UPGRADE-3.0.md?plain=1#L25.
+
 # v1.10.0 odc_eks - Optional vpc creation update procedure
 
 Making VPC creation optional has added a `count` to the `module.odc_eks.module.vpc` resource path.

--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -26,7 +26,7 @@ locals {
 }
 
 module "vpc" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v5.1.1"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v5.5.2"
 
   count = var.create_vpc ? 1 : 0
 

--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -92,10 +92,10 @@ module "vpc_endpoints" {
         module.vpc[0].private_route_table_ids,
         module.vpc[0].public_route_table_ids
       ])
-
-      tags = local.tags
     }
   }
+
+  tags = local.tags
 }
 
 # Creates network and Kuberenetes master nodes

--- a/odc_eks/waf.tf
+++ b/odc_eks/waf.tf
@@ -429,8 +429,8 @@ resource "aws_kinesis_firehose_delivery_stream" "waf_delivery_stream" {
     role_arn   = aws_iam_role.waf_firehose_role[0].arn
     bucket_arn = data.aws_s3_bucket.waf_log_bucket[0].arn
 
-    buffer_size     = var.waf_firehose_buffer_size
-    buffer_interval = var.waf_firehose_buffer_interval
+    buffering_size     = var.waf_firehose_buffer_size
+    buffering_interval = var.waf_firehose_buffer_interval
 
     prefix              = "logs/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
     error_output_prefix = "errors/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/!{firehose:error-output-type}"


### PR DESCRIPTION
# Why this change is needed
> We made this change a while ago to our cluster in GNSS Informatics team so that we could move to AWS provider version 5.

