### PR TITLE
Cluster node iam update

### DIFF
--- a/odc_eks/modules/eks/variables.tf
+++ b/odc_eks/modules/eks/variables.tf
@@ -138,6 +138,12 @@ variable "log_retention_period" {
   default     = 30
 }
 
+variable "enable_ecr_pullthough_cache_permissions" {
+  type        = bool
+  description = "Create additional cluster node IAM permissions to allow cluster to use ecr pull-through cache rules."
+  default     = false
+}
+
 #--------------------------------------------------------------
 # Tags
 #--------------------------------------------------------------

--- a/odc_eks/modules/eks/worker_policy.tf
+++ b/odc_eks/modules/eks/worker_policy.tf
@@ -49,8 +49,38 @@ resource "aws_iam_policy" "eks_kube2iam" {
 
 }
 
+resource "aws_iam_policy" "ecr_pullthrough_cache" {
+  name        = "${var.cluster_id}-ecr-pull-through-cache"
+  path        = "/"
+  description = "Enables cluster to use ecr pull-through cache"
+
+  policy = <<-EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "ecr:BatchImportUpstreamImage",
+            "ecr:CreateRepository",
+            "ecr:TagResource",
+            "ecr:CreatePullThroughCacheRule"
+          ],
+          "Effect": "Allow",
+          "Resource": "*"
+        }
+      ]
+    }
+  EOF
+
+}
+
 resource "aws_iam_role_policy_attachment" "eks_node_kube2iam" {
   policy_arn = aws_iam_policy.eks_kube2iam.arn
+  role       = aws_iam_role.eks_node.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_pullthrough" {
+  policy_arn = aws_iam_policy.ecr_pullthrough_cache.arn
   role       = aws_iam_role.eks_node.name
 }
 

--- a/odc_eks/modules/eks/worker_policy.tf
+++ b/odc_eks/modules/eks/worker_policy.tf
@@ -50,9 +50,10 @@ resource "aws_iam_policy" "eks_kube2iam" {
 }
 
 resource "aws_iam_policy" "ecr_pullthrough_cache" {
+  count       = (var.enable_ecr_pullthough_cache_permissions ? 1 : 0)
   name        = "${var.cluster_id}-ecr-pull-through-cache"
   path        = "/"
-  description = "Enables cluster to use ecr pull-through cache"
+  description = "Enables cluster to use ecr pull-through cache."
 
   policy = <<-EOF
     {
@@ -80,6 +81,7 @@ resource "aws_iam_role_policy_attachment" "eks_node_kube2iam" {
 }
 
 resource "aws_iam_role_policy_attachment" "eks_node_pullthrough" {
+  count      = (var.enable_ecr_pullthough_cache_permissions ? 1 : 0)
   policy_arn = aws_iam_policy.ecr_pullthrough_cache.arn
   role       = aws_iam_role.eks_node.name
 }


### PR DESCRIPTION
# Why this change is needed
The new AWS ECR pull though cache feature is a easy, fully AWS managed service that allows docker images to be cached within ECR from a number of other upstream image registries, such as dockerhub, ghcr etc.  It significantly reduces the number of pull requests sent to upstream registries, mitigating the issue of hitting pull rate limits.


# Negative effects of this change
As this is a new AWS feature, and not currently in-scope of the current deployment, risks or negative impacts of this change are negligible 
