### PR TITLE
Remove --cloud-provider kubelet arg

### DIFF
--- a/odc_eks/modules/eks/worker_image.tf
+++ b/odc_eks/modules/eks/worker_image.tf
@@ -24,9 +24,8 @@ set -o xtrace
 id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
 ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
 /etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.eks.endpoint}' --b64-cluster-ca '${aws_eks_cluster.eks.certificate_authority[0].data}' '${aws_eks_cluster.eks.id}' ${var.extra_bootstrap_args} \
---kubelet-extra-args \
-  "--node-labels=cluster=${aws_eks_cluster.eks.id},nodegroup=${var.node_group_name},nodetype=ondemand,instance-id=$id,ami-id=$ami \
-   --cloud-provider=aws ${var.extra_kubelet_args}"
+  --kubelet-extra-args "--node-labels=cluster=${aws_eks_cluster.eks.id},nodegroup=${var.node_group_name},nodetype=ondemand,instance-id=$id,ami-id=$ami \
+  ${var.extra_kubelet_args}"
 ${var.extra_userdata}
 USERDATA
 
@@ -37,9 +36,8 @@ set -o xtrace
 id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
 ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
 /etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.eks.endpoint}' --b64-cluster-ca '${aws_eks_cluster.eks.certificate_authority[0].data}' '${aws_eks_cluster.eks.id}' ${var.extra_bootstrap_args} \
---kubelet-extra-args \
-  "--node-labels=cluster=${aws_eks_cluster.eks.id},nodegroup=${var.node_group_name},nodetype=spot,instance-id=$id,ami-id=$ami \
-   --cloud-provider=aws ${var.extra_kubelet_args}"
+  --kubelet-extra-args "--node-labels=cluster=${aws_eks_cluster.eks.id},nodegroup=${var.node_group_name},nodetype=spot,instance-id=$id,ami-id=$ami \
+  ${var.extra_kubelet_args}"
 ${var.extra_userdata}
 USERDATA
 


### PR DESCRIPTION

# Why this change is needed

This flag was deprecated in < Kubernetes 1.23 and has been removed in 1.27 and now causes the `kubelet` to fail to start.

# Negative effects of this change

None, EKS 1.23 has no Extended Support so clusters should no longer exist.


I also adjusted the indentation of the args to `boostrap.sh` to be slightly more readable as they were misleading.