### PR TITLE
Fix a simple terraform error

### DIFF
--- a/odc_eks/modules/eks/worker_policy.tf
+++ b/odc_eks/modules/eks/worker_policy.tf
@@ -82,7 +82,7 @@ resource "aws_iam_role_policy_attachment" "eks_node_kube2iam" {
 
 resource "aws_iam_role_policy_attachment" "eks_node_pullthrough" {
   count      = (var.enable_ecr_pullthough_cache_permissions ? 1 : 0)
-  policy_arn = aws_iam_policy.ecr_pullthrough_cache.arn
+  policy_arn = aws_iam_policy.ecr_pullthrough_cache[0].arn
   role       = aws_iam_role.eks_node.name
 }
 


### PR DESCRIPTION

# Why this change is needed
Fixing this error:

│ Error: Missing resource instance key
│
│   on ../../../../datacube-k8s-eks/odc_eks/modules/eks/worker_policy.tf line 85, in resource "aws_iam_role_policy_attachment" "eks_node_pullthrough":
│   85:   policy_arn = aws_iam_policy.ecr_pullthrough_cache.arn
│
│ Because aws_iam_policy.ecr_pullthrough_cache has "count" set, its attributes must be accessed on specific instances.

# Negative effects of this change
None