### PR TITLE
Restore previous cluster-auth behaviour

### DIFF
--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -73,15 +73,15 @@ module "vpc" {
 
 moved {
   from = module.vpc[0].aws_vpc_endpoint.s3[0]
-  to   =  module.vpc_endpoints[0].aws_vpc_endpoint.this["s3"]
+  to   = module.vpc_endpoints[0].aws_vpc_endpoint.this["s3"]
 }
 
 module "vpc_endpoints" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git//modules/vpc-endpoints?ref=v5.1.1"
   count  = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
 
-  vpc_id = module.vpc[0].vpc_id
-  security_group_ids = [ module.vpc[0].default_security_group_id ]
+  vpc_id             = module.vpc[0].vpc_id
+  security_group_ids = [module.vpc[0].default_security_group_id]
 
   endpoints = {
     s3 = {

--- a/odc_eks/modules/eks/main.tf
+++ b/odc_eks/modules/eks/main.tf
@@ -12,6 +12,7 @@ resource "aws_eks_cluster" "eks" {
 
   access_config {
     authentication_mode = "API_AND_CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = true
   }
 
   depends_on = [

--- a/odc_eks/modules/eks/main.tf
+++ b/odc_eks/modules/eks/main.tf
@@ -11,7 +11,7 @@ resource "aws_eks_cluster" "eks" {
   }
 
   access_config {
-    authentication_mode = "API_AND_CONFIG_MAP"
+    authentication_mode                         = "API_AND_CONFIG_MAP"
     bootstrap_cluster_creator_admin_permissions = true
   }
 


### PR DESCRIPTION
A previous change adding an `access_config` block resulted in **new** clusters failing to allow auth for the rest of the toolchain (with no change for existing clusters). This rectifies that issue and there are also some minor `terraform fmt` fixes.
