### PR TITLE
added update_default_version parameter and set default to false

### DIFF
--- a/odc_eks/modules/eks/variables.tf
+++ b/odc_eks/modules/eks/variables.tf
@@ -185,3 +185,9 @@ variable "metadata_options" {
   type        = map(any)
   default     = {}
 }
+
+variable "update_default_version" {
+  description = "Automatically switch to newest launch template version"
+  type        = string
+  default     = "false"
+}

--- a/odc_eks/modules/eks/worker_image.tf
+++ b/odc_eks/modules/eks/worker_image.tf
@@ -44,10 +44,11 @@ USERDATA
 }
 
 resource "aws_launch_template" "node" {
-  name_prefix   = aws_eks_cluster.eks.id
-  image_id      = local.ami_id
-  user_data     = base64encode(local.eks-node-userdata)
-  instance_type = var.default_worker_instance_type
+  name_prefix            = aws_eks_cluster.eks.id
+  image_id               = local.ami_id
+  user_data              = base64encode(local.eks-node-userdata)
+  instance_type          = var.default_worker_instance_type
+  update_default_version = var.update_default_version
 
   metadata_options {
     http_endpoint               = lookup(var.metadata_options, "http_endpoint", null)

--- a/odc_eks/vpc_support.tf
+++ b/odc_eks/vpc_support.tf
@@ -11,9 +11,9 @@ module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  bucket = var.flow_log_s3_bucket_name
+  bucket        = var.flow_log_s3_bucket_name
   attach_policy = true
-  policy = data.aws_iam_policy_document.flow_log_s3[0].json
+  policy        = data.aws_iam_policy_document.flow_log_s3[0].json
 
   force_destroy = true
 


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed
> To remove Tenable Nessus agent from our EKS nodes. Required by Service Request 108 https://planner.cloud.microsoft/webui/v1/plan/hvJYH6QZmEe5JPmgyCFyecgAGsrC/view/board/task/rz_hdFatEku59BuiRxQXCMgAK5XE?tid=645b613a-a64c-4250-975f-5f69787d028d

> To action this request, we need to make changes to the launch templates provisioned by the EKS stack in the following bitbucket repo: "https://bitbucket.org/geoscienceaustralia/datakube/src". This change allows the variable "update_default_version" to be set at the workspace level in bitbucket. This allows us to remove the nessus agent installation script from the launch template user_data. 

# Negative effects of this change
> None expected. If no value is set for update_default_version, the default is false. I have set the variable explicitly as false in this repo. There will only be changes made when a further pull request is merged in the bitbucket repo. This PR would allow that change to be pushed one worspace at a time according to SDLC 
