### PR TITLE
added update_default_version variable in root module

### DIFF
--- a/odc_eks/main.tf
+++ b/odc_eks/main.tf
@@ -154,6 +154,7 @@ module "eks" {
   volume_size                  = var.volume_size
   volume_type                  = var.volume_type
   spot_volume_size             = var.spot_volume_size
+  update_default_version       = var.update_default_version
 
   # Default Tags
   owner       = var.owner

--- a/odc_eks/variables.tf
+++ b/odc_eks/variables.tf
@@ -380,3 +380,9 @@ variable "metadata_options" {
     error_message = "If http_tokens is required for nodes then http_endpoint must be enabled."
   }
 }
+
+variable "update_default_version" {
+  description = "Automatically switch to newest launch template version"
+  type        = string
+  default     = "false"
+}


### PR DESCRIPTION
**Any PRs will require running `terraform fmt -recursive` successfully first. Please install terraform version > `v0.15` on your local setup for this activity.**

# Why this change is needed
> Variable is required in root module 


# Negative effects of this change
> None. No changes to existing infra
